### PR TITLE
[WIP] Add 'Add fieldControl Example' to extension examples

### DIFF
--- a/Backend/AjaxRoutes.php
+++ b/Backend/AjaxRoutes.php
@@ -1,7 +1,7 @@
 <?php
 return [
-    'something-import-data' => [
-        'path' => '/something/import-data',
+    'examples-import-data' => [
+        'path' => '/examples/import-data',
         'target' => T3docs\Examples\Controller\Ajax\ImportDataController::class . '::importDataAction'
     ],
 ];

--- a/Backend/AjaxRoutes.php
+++ b/Backend/AjaxRoutes.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'something-import-data' => [
+        'path' => '/something/import-data',
+        'target' => T3docs\Examples\Controller\Ajax\ImportDataController::class . '::importDataAction'
+    ],
+];

--- a/Classes/Controller/Ajax/ImportDataController.php
+++ b/Classes/Controller/Ajax/ImportDataController.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace T3docs\Examples\Controller\Ajax;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ImportDataController
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return ResponseInterface
+     */
+    public function importDataAction(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        $queryParameters = $request->getParsedBody();
+        $id = (int)$queryParameters['id'];
+
+        if (empty($id)) {
+            $response->getBody()->write(json_encode(['success' => false]));
+            return $response;
+        }
+        $param = ' -id=' . $id;
+
+        // trigger data import (simplified as example)
+        $output = shell_exec('.' . DIRECTORY_SEPARATOR . 'import.sh' . $param);
+
+        $response->getBody()->write(json_encode(['success' => true, 'output' => $output]));
+        return $response;
+    }
+}

--- a/Classes/FormEngine/FieldControl/ImportDataControl.php
+++ b/Classes/FormEngine/FieldControl/ImportDataControl.php
@@ -11,7 +11,7 @@ class ImportDataControl extends AbstractNode
     {
         $result = [
             'iconIdentifier' => 'import-data',
-            'title' => 'xxx' . $GLOBALS['LANG']->sL('LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:pages.importData'),
+            'title' => $GLOBALS['LANG']->sL('LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:pages.importData'),
             'linkAttributes' => [
                 'class' => 'importData ',
                 'data-id' => $this->data['databaseRow']['somefield']

--- a/Classes/FormEngine/FieldControl/ImportDataControl.php
+++ b/Classes/FormEngine/FieldControl/ImportDataControl.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace T3docs\Examples\FormEngine\FieldControl;
+
+use TYPO3\CMS\Backend\Form\AbstractNode;
+
+class ImportDataControl extends AbstractNode
+{
+    public function render()
+    {
+        $result = [
+            'iconIdentifier' => 'import-data',
+            'title' => 'xxx' . $GLOBALS['LANG']->sL('LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:pages.importData'),
+            'linkAttributes' => [
+                'class' => 'importData ',
+                'data-id' => $this->data['databaseRow']['somefield']
+            ],
+            'requireJsModules' => ['TYPO3/CMS/Examples/ImportData'],
+        ];
+        return $result;
+    }
+}

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -30,7 +30,7 @@ $temporaryColumn = [
         ],
     ],
     'tx_examples_import_data_control' => [
-        'label'   => $langFile . ':pages.somefield',
+        'label'   => $langFile . ':pages.tx_examples_import_data_control',
         'config'  => [
             'type' => 'input',
             'eval' => 'int, unique',
@@ -46,8 +46,13 @@ $temporaryColumn = [
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette(
     'pages',
     'media',
-    '--linebreak--,tx_examples_related_pages, tx_examples_import_data_control',
+    '--linebreak--,tx_examples_related_pages',
     'after:media'
+);
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+    'pages',
+    'tx_examples_import_data_control'
 );
 
 // Add an extra categories selection field to the pages table

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,13 +1,15 @@
 <?php
 defined('TYPO3_MODE') or die();
 
+$langFile = 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf';
+
 // Add a "related pages" field to demonstrate select-type fields with tree rendering
 // USAGE: TCA Reference > $TCA array reference > ['columns'][field name]['config'] / TYPE: "select"
 // https://docs.typo3.org/m/typo3/reference-tca/master/en-us/ColumnsConfig/Type/Select/Index.html#columns-select
 $temporaryColumn = [
     'tx_examples_related_pages' => [
         'exclude' => 0,
-        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:pages.tx_examples_related_pages',
+        'label' => $langFile . ':pages.tx_examples_related_pages',
         'config' => [
             'type' => 'select',
             'renderType' => 'selectTree',
@@ -27,12 +29,24 @@ $temporaryColumn = [
             ],
         ],
     ],
+    'tx_examples_import_data_control' => [
+        'label'   => $langFile . ':pages.somefield',
+        'config'  => [
+            'type' => 'input',
+            'eval' => 'int, unique',
+            'fieldControl' => [
+                'importControl' => [
+                    'renderType' => 'importDataControl'
+                ]
+            ]
+        ]
+    ],
 ];
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $temporaryColumn);
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette(
     'pages',
     'media',
-    '--linebreak--,tx_examples_related_pages',
+    '--linebreak--,tx_examples_related_pages, tx_examples_import_data_control',
     'after:media'
 );
 

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -45,6 +45,12 @@
 			<trans-unit id="pages.tx_examples_related_pages" xml:space="preserve">
 				<source>Related pages</source>
 			</trans-unit>
+			<trans-unit id="pages.tx_examples_import_data_control" xml:space="preserve">
+				<source>Ajax import example</source>
+			</trans-unit>
+			<trans-unit id="pages.importData" xml:space="preserve">
+				<source>Import data</source>
+			</trans-unit>
 			<trans-unit id="examples.pi_flexform.sheetGeneral" xml:space="preserve">
 				<source>General Setup</source>
 			</trans-unit>

--- a/Resources/Public/JavaScript/ImportData.js
+++ b/Resources/Public/JavaScript/ImportData.js
@@ -1,0 +1,49 @@
+/**
+ * Module: TYPO3/CMS/Examples/ImportData
+ *
+ * JavaScript to handle data import
+ * @exports TYPO3/CMS/Examples/ImportData
+ */
+define(function () {
+	'use strict';
+
+	/**
+	 * @exports TYPO3/CMS/Examples/ImportData
+	 */
+	var ImportData = {};
+
+	/**
+	 * @param {int} id
+	 */
+	ImportData.import = function (id) {
+		$.ajax({
+			type: 'POST',
+			url: TYPO3.settings.ajaxUrls['something-import-data'],
+			data: {
+				'id': id
+			}
+		}).done(function (response) {
+			if (response.success) {
+				top.TYPO3.Notification.success('Import Done', response.output);
+			} else {
+				top.TYPO3.Notification.error('Import Error!');
+			}
+		});
+	};
+
+	/**
+	 * initializes events using deferred bound to document
+	 * so AJAX reloads are no problem
+	 */
+	ImportData.initializeEvents = function () {
+
+		$('.importData').on('click', function (evt) {
+			evt.preventDefault();
+			ImportData.import($(this).attr('data-id'));
+		});
+	};
+
+	$(ImportData.initializeEvents);
+
+	return ImportData;
+});

--- a/Resources/Public/JavaScript/ImportData.js
+++ b/Resources/Public/JavaScript/ImportData.js
@@ -18,7 +18,7 @@ define(function () {
 	ImportData.import = function (id) {
 		$.ajax({
 			type: 'POST',
-			url: TYPO3.settings.ajaxUrls['something-import-data'],
+			url: TYPO3.settings.ajaxUrls['examples-import-data'],
 			data: {
 				'id': id
 			}

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -119,4 +119,11 @@ defined('TYPO3') or die();
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig(
         "@import 'EXT:examples/Configuration/TSconfig/User/*.typoscript'"
     );
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1485351217] = [
+        'nodeName' => 'importDataControl',
+        'priority' => 30,
+        'class' => T3docs\Examples\FormEngine\FieldControl\ImportDataControl::class
+    ];
+
 })();

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -26,7 +26,8 @@ CREATE TABLE tt_content (
 # Table structure for table 'pages'
 #
 CREATE TABLE pages (
-	tx_examples_related_pages text
+	tx_examples_related_pages text,
+    tx_examples_import_data_control INT(11) DEFAULT '0' NOT NULL,
 );
 
 #


### PR DESCRIPTION
Converting the theoretical example https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/FormEngine/Rendering/Index.html#add-fieldcontrol-example into one really running in the examples extension - However it still causes Javascript errrors