### PR TITLE
[TASK] Publish TER release by GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "**"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Publish new version to TER
+        uses: tomasnorre/typo3-upload-ter@v2
+        with:
+          api-token: ${{ secrets.TYPO3_API_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,12 @@
         "branch-alias": {
             "dev-master": "11.0.x-dev"
         }
+    },
+    "scripts": {
+        "prepare-release": [
+            "rm -rf .github",
+            "rm .gitignore",
+            "rm .editorconfig"
+        ]
     }
 }


### PR DESCRIPTION
Publish new releases automatically to the TYPO3 Extensions Repository along with the already-in-place deployments to Packagist and the TYPO3 documentation.

Fixes: #37 