### PR TITLE
[DOCS] Reference manual's start page with :doc:`<manual>:Index`

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -55,7 +55,7 @@ project_repository   = https://github.com/TYPO3-Documentation/t3docs-examples
 # You must uncomment all manuals you use in your cross-references
 #
 # Example usage:
-#   :ref:`t3contribute:start` will link to start page of Contribution Guide
+#   :doc:`t3contribute:Index` will link to start page of Contribution Guide
 # .................................................................................
 
 #t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/master/en-us/


### PR DESCRIPTION
Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/185