### PR TITLE
[FEATURE] Add returnUrl in module "Links"

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -310,6 +310,8 @@ class ModuleController extends ActionController implements LoggerAwareInterface
         $backendUriBuilder = GeneralUtility::makeInstance(\TYPO3\CMS\Backend\Routing\UriBuilder::class);
         $uriParameters = ['edit' => ['pages' => [1 => 'edit']]];
         $editPage1Link = $backendUriBuilder->buildUriFromRoute('record_edit', $uriParameters);
+        $pageUid = (int)($this->request->getQueryParams()['id'] ?? 0);
+        $returnUrl = (string)$backendUriBuilder->buildUriFromRoute('web_examples', ['id' => $pageUid, 'action' => 'links']);
 
         $uriParameters =
             [
@@ -325,7 +327,8 @@ class ModuleController extends ActionController implements LoggerAwareInterface
                                 1 => 'edit'
                             ]
                     ],
-                'columnsOnly' => 'title,doktype'
+                'columnsOnly' => 'title,doktype',
+                'returnUrl' => $returnUrl
             ];
         $editPagesDoktypeLink = $backendUriBuilder->buildUriFromRoute('record_edit', $uriParameters);
         $uriParameters =

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -117,6 +117,9 @@
 			<trans-unit id="function_links_new_haiku_with_title" xml:space="preserve">
 				<source>Create a new haiku with a predefined title</source>
 			</trans-unit>
+			<trans-unit id="function_links_returnUrl" xml:space="preserve">
+            	<source>with returnUrl to jump back to the module</source>
+            </trans-unit>
 
 			<trans-unit id="function_password" xml:space="preserve">
 				<source>Password hashes</source>

--- a/Resources/Private/Templates/Module/Links.html
+++ b/Resources/Private/Templates/Module/Links.html
@@ -28,7 +28,7 @@
 <p>
 	<a href="{editPagesDoktypeLink}">
 		<core:icon identifier="actions-document-open"/>
-		<f:translate key="function_links_edit_pages_doktype"/>
+		<f:translate key="function_links_edit_pages_doktype"/> (<f:translate key="function_links_returnUrl"/>)
 	</a>
 </p>
 <p>


### PR DESCRIPTION
In the backend module "Example module" in the function "Links",
there are several links to edit records. After the "close"
button is clicked in the form, the expected behaviour would be,
to jump back to the previously opened module.

This functionality can be implemented, by setting returnUrl to
the module route. This is now implemented in one of the links
and an appropriate label added.

Resolves: #84