### PR TITLE
[TASK] Add missing constraints in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,10 @@
         }
     },
     "require": {
-        "typo3/cms-core": "^12.0.0|dev-main",
-		"typo3/cms-fluid-styled-content": "^12.0.0|dev-main"
+		"typo3/cms-backend": "^12.0 || dev-main",
+        "typo3/cms-core": "^12.0 || dev-main",
+		"typo3/cms-fluid-styled-content": "^12.0 || dev-main",
+		"typo3/cms-linkvalidator": "^12.0 || dev-main"
     },
     "replace": {
         "typo3-ter/examples": "self.version"
@@ -37,5 +39,11 @@
             "rm .gitignore",
             "rm .editorconfig"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
+        }
     }
 }


### PR DESCRIPTION
Also, it is recommended to separate different versions with || instead of |.
See: https://getcomposer.org/doc/articles/versions.md#version-range

Additionally, allow plugins - which is necessary since composer 2.2, so
composer plugins are executed in this project.