### PR TITLE
[BUGFIX] Use custom CategoryRepository

### DIFF
--- a/Classes/DataProcessing/CustomCategoryProcessor.php
+++ b/Classes/DataProcessing/CustomCategoryProcessor.php
@@ -16,10 +16,10 @@
      * The TYPO3 project - inspiring people to share!
      */
 
+    use T3docs\Examples\Domain\Repository\CategoryRepository;
     use TYPO3\CMS\Core\Utility\GeneralUtility;
     use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
     use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
-    use TYPO3\CMS\Extbase\Domain\Repository\CategoryRepository;
 
     /**
      * Class for data processing comma separated categories

--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace T3docs\Examples\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+class Category extends AbstractEntity
+{
+    protected string $title = '';
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}

--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace T3docs\Examples\Domain\Repository;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+class CategoryRepository extends Repository
+{
+    public function initializeObject()
+    {
+        $querySettings = GeneralUtility::makeInstance(Typo3QuerySettings::class);
+        $querySettings->setRespectStoragePage(false);
+        $this->setDefaultQuerySettings($querySettings);
+    }
+}

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types = 1);
+
+return [
+    \T3docs\Examples\Domain\Model\Category::class => [
+        'tableName' => 'sys_category',
+    ],
+];


### PR DESCRIPTION
The CategoryRepository shipped with Extbase was removed in TYPO3 v12.
In addition, we have also to provide the model.