### PR TITLE
[TASK] Store installation artifacts in .Build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.Build
+composer.lock
 *GENERATED*

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,9 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "examples"
-        },
+            "extension-key": "examples",
+			"web-dir": ".Build/web"
+		},
         "branch-alias": {
             "dev-master": "12.0.x-dev"
         }
@@ -41,6 +42,8 @@
         "allow-plugins": {
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true
-        }
-    }
+        },
+		"bin-dir": ".Build/bin",
+		"vendor-dir": ".Build/vendor"
+	}
 }


### PR DESCRIPTION
This makes the project's root folder less cluttered when executing
"composer update".

vendor -> .Build/vendor
vendor/bin -> .Build/bin
public -> .Build/web

This is in line with the bootstrap_package and styleguide extensions.

Additionally, ignore the .Build folder and a composer.lock file.