### PR TITLE
[TASK] Introduce .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.* export-ignore


### PR DESCRIPTION
This avoids installing dot-files (development files) when running
"composer require" with a stable version.