### PR TITLE
[BUGFIX] Add missing icons to backend modules

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -15,6 +15,7 @@ return [
         'path' => '/module/page/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/Module/locallang_mod.xlf',
         'extensionName' => 'Examples',
+        'iconIdentifier' => 'module-generic',
         'controllerActions' => [
             ModuleController::class => [
                 'flash','tree','clipboard','links','fileReference','fileReferenceCreate',
@@ -29,6 +30,7 @@ return [
         'path' => '/module/system/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf',
         'extensionName' => 'Examples',
+        'iconIdentifier' => 'module-generic',
         'routes' => [
            '_default' => [
                'target' => AdminModuleController::class . '::handleRequest',


### PR DESCRIPTION
This avoids the missing image icon displayed for backend
modules. We use the "module-generic" icon identifier provided
by TYPO3.