### PR TITLE
[TASK] Clean up module registration

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -15,7 +15,7 @@ return [
         'path' => '/module/page/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/Module/locallang_mod.xlf',
         'extensionName' => 'Examples',
-        'iconIdentifier' => 'module-generic',
+        'iconIdentifier' => 'tx_examples-backend-module',
         'controllerActions' => [
             ModuleController::class => [
                 'flash','tree','clipboard','links','fileReference','fileReferenceCreate',
@@ -30,7 +30,7 @@ return [
         'path' => '/module/system/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf',
         'extensionName' => 'Examples',
-        'iconIdentifier' => 'module-generic',
+        'iconIdentifier' => 'tx_examples-backend-module',
         'routes' => [
            '_default' => [
                'target' => AdminModuleController::class . '::handleRequest',

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -23,4 +23,8 @@ return [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:examples/Resources/Public/Images/ArchivePage.svg',
     ],
+    'tx_examples-backend-module' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:examples/Resources/Public/Images/BackendModule.svg',
+    ],
 ];

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -5,25 +5,6 @@ defined('TYPO3') or die();
 // encapsulate all locally defined variables
 (function () {
 
-    // Add examples BE module
-    // This module is used to demonstrate some features and take screenshots
-    // Register the backend module
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-        'Examples',
-        'tools', // Make module a submodule of 'Admin Tools'
-        'examples', // Submodule key
-        '', // Position
-        [
-            // An array holding the controller-action-combinations that are accessible
-            \T3docs\Examples\Controller\ModuleController::class => 'flash,log,tree,debug,clipboard,password,links,fileReference,fileReferenceCreate',
-        ],
-        [
-            'access' => 'user,group',
-            'icon' => 'EXT:examples/Resources/Public/Images/BackendModule.svg',
-            'labels' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf'
-        ]
-    );
-
     // Add extra fields to User Settings (field is defined for TCA too in Configuration/TCA/Overrides/be_users.php)
     // IMPORTANT: We need to define a dependency on sysext:setup to ensure that the loading order is correct and
     // the configuration is properly applied.


### PR DESCRIPTION
A left-over from the migration to Configuration/Backend/Modules.php
is ext_tables.php is removed.

This way, I encountered also that there is already a backend module
icon in this extension, which is now registered and used for the two
backend modules.