### PR TITLE
[TASK] Remove superfluous context menu item provider registration

### DIFF
--- a/Classes/ContextMenu/HelloWorldItemProvider.php
+++ b/Classes/ContextMenu/HelloWorldItemProvider.php
@@ -29,7 +29,7 @@ class HelloWorldItemProvider extends AbstractProvider
         'hello' => [
             'type' => 'item',
             'label' => 'Hello World', // you can use "LLL:" syntax here
-            'iconIdentifier' => 'actions-document-info',
+            'iconIdentifier' => 'actions-lightbulb-on',
             'callbackAction' => 'helloWorld' //name of the function in the JS file
         ]
     ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -111,6 +111,4 @@ defined('TYPO3') or die();
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['de']
             ['EXT:frontend/Resources/Private/Language/locallang_tca.xlf'][] =
         'EXT:examples/Resources/Private/Language/de.custom.xlf';
-
-    $GLOBALS['TYPO3_CONF_VARS']['BE']['ContextMenu']['ItemProviders'][1488274371] = \T3docs\Examples\ContextMenu\HelloWorldItemProvider::class;
 })();


### PR DESCRIPTION
This is not necessary anymore, as every class implementing
`TYPO3\CMS\Backend\ContextMenu\ItemProviders\ProviderInterface`
is registered automatically.

Additionally, the context menu icon was changed to differ
from the info context menu with the same icon directly above.