### PR TITLE
[TASK] Use new TCA types

### DIFF
--- a/Configuration/TCA/tx_examples_dummy.php
+++ b/Configuration/TCA/tx_examples_dummy.php
@@ -5,7 +5,6 @@ return [
         'label' => 'title',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'type' => 'record_type',
         'default_sortby' => 'ORDER BY title',
         'delete' => 'deleted',
@@ -51,17 +50,17 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => 30,
-                'eval' => 'required,trim',
+                'required' => true,
+                'eval' => 'trim',
             ],
         ],
         'some_date' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tx_examples_dummy.some_date',
             'config' => [
-                'type' => 'input',
-                'renderType' => 'inputDateTime',
+                'type' => 'datetime',
+                'format' => 'date',
                 'size' => 12,
-                'eval' => 'date',
             ],
         ],
         'enforce_date' => [
@@ -85,7 +84,7 @@ return [
         // NOTE: there are alternate versions of this row to demonstrate various features
         //		'0' => array('showitem' => 'hidden, record_type, title, some_date '),
         // Use this row to demonstrate usage of palettes
-        '0' => ['showitem' => 'hidden, record_type, title, some_date, --palette--;;1'],
+        '0' => ['showitem' => 'hidden, record_type, title, some_date, description, --palette--;;1'],
         // Use this row when discussing special configuration nowrap
         // (paste this into the description field: This is a very long text that will not wrap when I get to the end of the box, which is very far away, away, away, away, away, away)
         //		'0' => array('showitem' => 'hidden, record_type, title, description;;;nowrap, some_date;;1 '),

--- a/Configuration/TCA/tx_examples_haiku.php
+++ b/Configuration/TCA/tx_examples_haiku.php
@@ -6,14 +6,12 @@ return [
         'label_userFunc' => \T3docs\Examples\Userfuncs\Tca::class . '->haikuTitle',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'default_sortby' => 'ORDER BY title',
         'delete' => 'deleted',
         'enablecolumns' => [
             'disabled' => 'hidden',
         ],
         'searchFields' => 'title,poem',
-        'dividers2tabs' => true,
         'typeicon_classes' => [
             'default' => 'tx_examples-haiku',
         ],
@@ -46,7 +44,8 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => 30,
-                'eval' => 'required,trim',
+                'required' => true,
+                'eval' => 'trim',
             ],
         ],
         'poem' => [
@@ -131,9 +130,8 @@ return [
             'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tx_examples_haiku.weirdness',
             'description' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tx_examples_haiku.weirdness.description',
             'config' => [
-                'type' => 'input',
+                'type' => 'number',
                 'size' => 10,
-                'eval' => 'int',
                 'wizards' => [
                     'specialWizard' => [
                         'type' => 'userFunc',
@@ -150,19 +148,16 @@ return [
             'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tx_examples_haiku.color',
             'description' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tx_examples_haiku.color.description',
             'config' => [
-                'type' => 'input',
+                'type' => 'color',
                 'size' => 10,
-                'eval' => 'trim',
-                'renderType' => 'colorpicker',
             ],
         ],
         'angle' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tx_examples_haiku.angle',
             'config' => [
-                'type' => 'input',
+                'type' => 'number',
                 'size' => 5,
-                'eval' => 'trim,int',
                 'range' => [
                     'lower' => -90,
                     'upper' => 90,
@@ -193,7 +188,6 @@ return [
             'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tx_examples_haiku.related_records',
             'config' => [
                 'type' => 'group',
-                'internal_type' => 'db',
                 'allowed' => 'pages, tt_content',
                 'size' => 5,
                 'minitems' => 0,


### PR DESCRIPTION
Additionally, cruser_id was also removed. dividers2tabs was removed some versions ago
and has no influence in modern versions.

In dummy table a description field was configured but not displayed, this was also
corrected.