### PR TITLE
disable xclass, see #60

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,9 +7,11 @@ defined('TYPO3') or die();
 (function () {
     // Load XCLASSing of db_new
     // USAGE: Core APIs > TYPO3 API overview > PHP Class Extension > Which classes? > Example - Adding a small feature in the interface
+    /* Disabled, @see #60
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Backend\Controller\NewRecordController::class] = [
         'className' => \T3docs\Examples\Xclass\NewRecordController::class,
     ];
+    */
 
     // Define custom permission options
     // USAGE: Core APIs > TYPO3 API overview > Various examples > Custom permission

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,7 +7,9 @@ defined('TYPO3') or die();
 (function () {
     // Load XCLASSing of db_new
     // USAGE: Core APIs > TYPO3 API overview > PHP Class Extension > Which classes? > Example - Adding a small feature in the interface
-    /* Disabled, @see #60
+    /*
+    // Disabled, @see #60
+    // @TODO: 1) find new case for an xclass, 2) remove old xclass, 3) add new xclass
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Backend\Controller\NewRecordController::class] = [
         'className' => \T3docs\Examples\Xclass\NewRecordController::class,
     ];


### PR DESCRIPTION
Target is to replace the xclass by another one.  
The previous example can't be updated without much hacks--if at all.