### PR TITLE
[FEATURE] Add example for sending HTTP request with Guzzle

### DIFF
--- a/Classes/Command/CatFactCommand.php
+++ b/Classes/Command/CatFactCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3docs\Examples\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use T3docs\Examples\Http\CatFactRequester;
+
+final class CatFactCommand extends Command
+{
+    public function __construct(
+        private readonly CatFactRequester $catFactRequester,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setHelp('Prints out a random fact about cats retrieved from an API call');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title($this->getDescription());
+
+        try {
+            $fact = $this->catFactRequester->request();
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->writeln($fact);
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Command/MeowInformationCommand.php
+++ b/Classes/Command/MeowInformationCommand.php
@@ -20,7 +20,7 @@ final class MeowInformationCommand extends Command
 
     protected function configure()
     {
-        $this->setHelp('Prints out a random information about cats retrieved from an API call');
+        $this->setHelp('Prints random information about cats retrieved from an API call');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/Classes/Command/MeowInformationCommand.php
+++ b/Classes/Command/MeowInformationCommand.php
@@ -8,19 +8,19 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use T3docs\Examples\Http\CatFactRequester;
+use T3docs\Examples\Http\MeowInformationRequester;
 
-final class CatFactCommand extends Command
+final class MeowInformationCommand extends Command
 {
     public function __construct(
-        private readonly CatFactRequester $catFactRequester,
+        private readonly MeowInformationRequester $requester,
     ) {
         parent::__construct();
     }
 
     protected function configure()
     {
-        $this->setHelp('Prints out a random fact about cats retrieved from an API call');
+        $this->setHelp('Prints out a random information about cats retrieved from an API call');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -29,14 +29,14 @@ final class CatFactCommand extends Command
         $io->title($this->getDescription());
 
         try {
-            $fact = $this->catFactRequester->request();
+            $detail = $this->requester->request();
         } catch (\Exception $e) {
             $io->error($e->getMessage());
 
             return Command::FAILURE;
         }
 
-        $io->writeln($fact);
+        $io->writeln($detail);
 
         return Command::SUCCESS;
     }

--- a/Classes/Http/CatFactRequester.php
+++ b/Classes/Http/CatFactRequester.php
@@ -46,7 +46,7 @@ final class CatFactRequester
         }
 
         // Get the content as a string on a successful request
-        return json_decode($response->getBody()->getContents(), true)['fact1']
+        return json_decode($response->getBody()->getContents(), true)['fact']
             ?? throw new \RuntimeException('No fact available');
     }
 }

--- a/Classes/Http/CatFactRequester.php
+++ b/Classes/Http/CatFactRequester.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace T3docs\Examples\Http;
+
+use TYPO3\CMS\Core\Http\RequestFactory;
+
+final class CatFactRequester
+{
+    private const API_URL = 'https://catfact.ninja/fact';
+
+    // We need later the RequestFactory for creating and sending a request,
+    // so we inject it into the class via constructor injection.
+    public function __construct(
+        private readonly RequestFactory $requestFactory,
+    ) {
+    }
+
+    public function request(): string
+    {
+        // Additional headers for this specific request
+        // See: https://docs.guzzlephp.org/en/stable/request-options.html
+        $additionalOptions = [
+            'headers' => ['Cache-Control' => 'no-cache'],
+            'allow_redirects' => false,
+        ];
+
+        // Get a PSR-7 compliant response object
+        $response = $this->requestFactory->request(
+            self::API_URL,
+            'GET',
+            $additionalOptions
+        );
+
+        if ($response->getStatusCode() !== 200) {
+            throw new \RuntimeException(
+                'Returned status code is ' . $response->getStatusCode()
+            );
+        }
+
+        if ($response->getHeaderLine('Content-Type') !== 'application/json') {
+            throw new \RuntimeException(
+                'No JSON returned'
+            );
+        }
+
+        // Get the content as a string on a successful request
+        return json_decode($response->getBody()->getContents(), true)['fact1']
+            ?? throw new \RuntimeException('No fact available');
+    }
+}

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -26,7 +26,7 @@ final class MeowInformationRequester
             'allow_redirects' => false,
         ];
 
-        // Get a PSR-7 compliant response object
+        // Get a PSR-7-compliant response object
         $response = $this->requestFactory->request(
             self::API_URL,
             'GET',

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -10,7 +10,7 @@ final class MeowInformationRequester
 {
     private const API_URL = 'https://catfact.ninja/fact';
 
-    // We need later the RequestFactory for creating and sending a request,
+    // We need the RequestFactory for creating and sending a request,
     // so we inject it into the class via constructor injection.
     public function __construct(
         private readonly RequestFactory $requestFactory,

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -11,7 +11,7 @@ final class MeowInformationRequester
     private const API_URL = 'https://catfact.ninja/fact';
 
     // We need the RequestFactory for creating and sending a request,
-    // so we inject it into the class via constructor injection.
+    // so we inject it into the class using constructor injection.
     public function __construct(
         private readonly RequestFactory $requestFactory,
     ) {

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -6,7 +6,7 @@ namespace T3docs\Examples\Http;
 
 use TYPO3\CMS\Core\Http\RequestFactory;
 
-final class CatFactRequester
+final class MeowInformationRequester
 {
     private const API_URL = 'https://catfact.ninja/fact';
 

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -47,6 +47,6 @@ final class MeowInformationRequester
 
         // Get the content as a string on a successful request
         return json_decode($response->getBody()->getContents(), true)['fact']
-            ?? throw new \RuntimeException('No fact available');
+            ?? throw new \RuntimeException('No information available');
     }
 }

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -41,7 +41,7 @@ final class MeowInformationRequester
 
         if ($response->getHeaderLine('Content-Type') !== 'application/json') {
             throw new \RuntimeException(
-                'No JSON returned'
+                'The request did not return JSON data'
             );
         }
 

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -15,8 +15,8 @@ services:
    T3docs\Examples\Controller\AdminModuleController:
       tags: ['backend.controller']
 
-   T3docs\Examples\Command\CatFactCommand:
+   T3docs\Examples\Command\MeowInformationCommand:
       tags:
          - name: 'console.command'
-           command: 'examples:catfact'
-           description: 'Cat Fact'
+           command: 'examples:meow'
+           description: 'Meow Information'

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -14,3 +14,9 @@ services:
 
    T3docs\Examples\Controller\AdminModuleController:
       tags: ['backend.controller']
+
+   T3docs\Examples\Command\CatFactCommand:
+      tags:
+         - name: 'console.command'
+           command: 'examples:catfact'
+           description: 'Cat Fact'


### PR DESCRIPTION
This example will be used as code snippet for
https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Http/Index.html#basic-usage

The main part is the MeowInformationRequester class which requests a cat information
from a public API. To hold the example small only the needed code is
available in this class. To really work with the MeowInformationRequester a
MeowInformationCommand is introduced which can be called with
`vendor/bin/typo3 examples:meow` and displays a random information piece
about cats.

Resolves: #108