### PR TITLE
[BUGFIX] Remove duplicate adding of TypoScript

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -2,14 +2,13 @@
 
 defined('TYPO3') or die();
 
-// Declare static TS file
+// Declare static TS files
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'examples',
     'Configuration/TypoScript/',
     'Examples TypoScript'
 );
 
-// Declare static TS file
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'examples',
     'Configuration/TypoScript/HmenuSpecial/',

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -2,7 +2,7 @@
 
 defined('TYPO3') or die();
 
-// Declare static TS files
+// Declare static TypoScript files
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'examples',
     'Configuration/TypoScript/',

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -4,13 +4,6 @@ defined('TYPO3') or die();
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
-// Declare static TS file
-ExtensionManagementUtility::addStaticFile(
-    'examples',
-    'Configuration/TypoScript/',
-    'Examples TypoScript'
-);
-
 // Add a "no print" checkbox
 // USAGE: TCA Reference >  $TCA array reference > Extending the $TCA array
 $temporaryColumn = [


### PR DESCRIPTION
The `addStaticFile` call on `Configuration/TypoScript/`
is called in `tt_content.php` and `sys_template.php`.
Therefore, one is removed.