### PR TITLE
Ignore .idea files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .Build
 composer.lock
 *GENERATED*


### PR DESCRIPTION
These are generated by PHPStorm which is widely used. They should never be committed.