### PR TITLE
[BUGFIX] Inject Request object into StandaloneView

### DIFF
--- a/Classes/Controller/Haiku/DetailController.php
+++ b/Classes/Controller/Haiku/DetailController.php
@@ -43,7 +43,7 @@ class DetailController
     {
         $this->conf = $conf;
         $this->loadFlexFormSettings();
-        $this->view = $this->viewService->createView($this->conf, 'Haiku/Detail');
+        $this->view = $this->viewService->createView($request, $this->conf, 'Haiku/Detail');
 
         $parameter = $request->getQueryParams()['tx_examples_haiku']??[];
         $action = $parameter['action'] ?? '';

--- a/Classes/Controller/Haiku/ListController.php
+++ b/Classes/Controller/Haiku/ListController.php
@@ -27,7 +27,7 @@ class ListController
     {
         $this->conf = $conf;
         $this->loadFlexFormSettings();
-        $view = $this->viewService->createView($this->conf, 'Haiku/List');
+        $view = $this->viewService->createView($request, $this->conf, 'Haiku/List');
         $view->assignMultiple([
             'haikus' => $this->haikuRepository->findAll(),
         ]);

--- a/Classes/Service/StandaloneViewService.php
+++ b/Classes/Service/StandaloneViewService.php
@@ -2,22 +2,24 @@
 
 namespace T3docs\Examples\Service;
 
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 
 class StandaloneViewService
 {
-    public function createView(array $config, string $templateName, string $format = 'html'): StandaloneView
+    public function createView(ServerRequestInterface $request, array $config, string $templateName, string $format = 'html'): StandaloneView
     {
         $view = GeneralUtility::makeInstance(StandaloneView::class);
+        $view->setRequest($request);
         $view->setLayoutRootPaths([
-            GeneralUtility::getFileAbsFileName($config['view']['layoutRootPath']?? 'EXT:examples/Resources/Private/Layouts'),
+            GeneralUtility::getFileAbsFileName($config['view']['layoutRootPath'] ?? 'EXT:examples/Resources/Private/Layouts'),
         ]);
         $view->setPartialRootPaths([
-            GeneralUtility::getFileAbsFileName($config['view']['partialRootPath']?? 'EXT:examples/Resources/Private/Partials'),
+            GeneralUtility::getFileAbsFileName($config['view']['partialRootPath'] ?? 'EXT:examples/Resources/Private/Partials'),
         ]);
         $view->setTemplateRootPaths([
-            GeneralUtility::getFileAbsFileName($config['view']['templateRootPath']?? 'EXT:examples/Resources/Private/Templates'),
+            GeneralUtility::getFileAbsFileName($config['view']['templateRootPath'] ?? 'EXT:examples/Resources/Private/Templates'),
         ]);
         $view->setFormat($format);
         $view->setTemplate($templateName);


### PR DESCRIPTION
Since the StandaloneView does not create an Extbase request anymore, calling the Haiku list plugin throws the following warning:

ViewHelper f:link.page needs a request implementing ServerRequestInterface.

This is fixed by setting the current request object into the StandaloneView from the plugin.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/197