### PR TITLE
[BUGFIX] Fix the Github Linkhandler for TYPO3 v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - [FEATURE] Password hashing examples
 
+## BUGFIX
+
+- [BUGFIX] Fix the Linkhandler example
+
 # 11.1.1
 
 ## TASK

--- a/Classes/LinkHandler/GitHubLinkHandler.php
+++ b/Classes/LinkHandler/GitHubLinkHandler.php
@@ -87,6 +87,7 @@ class GitHubLinkHandler implements LinkHandlerInterface
         $this->linkBrowser = $linkBrowser;
         $this->iconFactory = GeneralUtility::makeInstance(IconFactory::class);
         $this->pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $this->configuration = $configuration;
     }
 
     /**
@@ -128,11 +129,8 @@ class GitHubLinkHandler implements LinkHandlerInterface
     public function render(ServerRequestInterface $request): string
     {
         $this->pageRenderer->loadRequireJsModule('TYPO3/CMS/Examples/GitHubLinkHandler');
-        $templateRootPaths = $this->view->getTemplateRootPaths();
-        $this->view->setTemplateRootPaths([
-            ...$this->view->getTemplateRootPaths(),
-            GeneralUtility::getFileAbsFileName('EXT:examples/Resources/Private/Templates/LinkBrowser')
-        ]);
+        $this->view->getRequest()->setControllerExtensionName('examples');
+        $this->view->setTemplateRootPaths(['EXT:examples/Resources/Private/Templates/LinkBrowser']);
 
         $this->view->assign('project', $this->configuration['project']);
         $this->view->assign('action', $this->configuration['action']);

--- a/Classes/LinkHandler/GithubLinkBuilder.php
+++ b/Classes/LinkHandler/GithubLinkBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace T3docs\Examples\LinkHandler;
+
+use TYPO3\CMS\Core\LinkHandling\LinkService;
+use TYPO3\CMS\Frontend\Typolink\AbstractTypolinkBuilder;
+use TYPO3\CMS\Frontend\Typolink\LinkResult;
+use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
+use TYPO3\CMS\Frontend\Typolink\UnableToLinkException;
+
+/**
+ * Builds a TypoLink to a Github issue
+ */
+class GithubLinkBuilder extends AbstractTypolinkBuilder
+{
+    const TYPE_GITHUB = 'github';
+
+    /**
+     * @inheritdoc
+     */
+    public function build(
+        array &$linkDetails,
+        string $linkText,
+        string $target,
+        array $conf
+    ): LinkResultInterface {
+        $issueId = trim($linkDetails['value']);
+        if (str_starts_with($issueId, '#')) {
+            $issueId = substr($issueId, 1);
+        }
+        $issueId = (int) $issueId;
+        if ($issueId < 1) {
+            throw new UnableToLinkException(
+                '"' . $linkDetails['value'] . '" is not a valid Github issue number.',
+                // Use the Unix timestamp of the time of creation of this message
+                1665304602,
+                null,
+                $linkText
+            );
+        }
+        $url = 'https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/' . $issueId;
+
+        return (new LinkResult(self::TYPE_GITHUB, $url))
+            ->withTarget($target)
+            ->withLinkConfiguration($conf)
+            ->withLinkText($linkText);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -35,6 +35,8 @@ defined('TYPO3') or die();
         'class' => \T3docs\Examples\Form\Element\SpecialFieldElement::class,
     ];
 
+    $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['github'] =
+        \T3docs\Examples\LinkHandler\GithubLinkBuilder::class;
 
     // Add example configuration for the logging API
     $GLOBALS['TYPO3_CONF_VARS']['LOG']['T3docs']['Examples']['Controller']['writerConfiguration'] = [


### PR DESCRIPTION
In preparation for also fixing it for v12

I will do a manual preport to v12

references https://github.com/TYPO3-Documentation/t3docs-examples/issues/77

releases: 11.5, main