### PR TITLE
[Forwardport] [BUGFIX] Correct GitHub Linkhandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Use ContextualFeedbackSeverity for flash message severity (#87)
 
 ### Fixed
+- Fix the Github Linkhandler for TYPO3 v11 (#133)
 - Fix new record controller xClass example (#64)
 - defined('TYPO3') or die(); (#66)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Use ContextualFeedbackSeverity for flash message severity (#87)
 
 ### Fixed
+- Forward-port correcting GitHub linkhandler (#133)
 - Fix the count-buttons in FlashMessage example (#135)
 - Fix TCA userfunc PHP warnings when no record is created yet (#134)
 - Fix new record controller xClass example (#64)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Use ContextualFeedbackSeverity for flash message severity (#87)
 
 ### Fixed
-- Fix the Github Linkhandler for TYPO3 v11 (#133)
 - Fix the count-buttons in FlashMessage example (#135)
 - Fix TCA userfunc PHP warnings when no record is created yet (#134)
 - Fix new record controller xClass example (#64)

--- a/Classes/LinkHandler/GitHubLinkHandler.php
+++ b/Classes/LinkHandler/GitHubLinkHandler.php
@@ -87,6 +87,7 @@ class GitHubLinkHandler implements LinkHandlerInterface
         $this->linkBrowser = $linkBrowser;
         $this->iconFactory = GeneralUtility::makeInstance(IconFactory::class);
         $this->pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $this->configuration = $configuration;
     }
 
     /**
@@ -127,10 +128,8 @@ class GitHubLinkHandler implements LinkHandlerInterface
     public function render(ServerRequestInterface $request): string
     {
         $this->pageRenderer->loadRequireJsModule('TYPO3/CMS/Examples/GitHubLinkHandler');
-        $this->view->setTemplateRootPaths([
-            ...$this->view->getTemplateRootPaths(),
-            GeneralUtility::getFileAbsFileName('EXT:examples/Resources/Private/Templates/LinkBrowser'),
-        ]);
+        $this->view->getRequest()->setControllerExtensionName('examples');
+        $this->view->setTemplateRootPaths(['EXT:examples/Resources/Private/Templates/LinkBrowser']);
 
         $this->view->assign('project', $this->configuration['project']);
         $this->view->assign('action', $this->configuration['action']);

--- a/Classes/LinkHandler/GithubLinkBuilder.php
+++ b/Classes/LinkHandler/GithubLinkBuilder.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 
 namespace T3docs\Examples\LinkHandler;
 
-use TYPO3\CMS\Core\LinkHandling\LinkService;
 use TYPO3\CMS\Frontend\Typolink\AbstractTypolinkBuilder;
 use TYPO3\CMS\Frontend\Typolink\LinkResult;
 use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
@@ -43,7 +42,7 @@ class GithubLinkBuilder extends AbstractTypolinkBuilder
         if (str_starts_with($issueId, '#')) {
             $issueId = substr($issueId, 1);
         }
-        $issueId = (int) $issueId;
+        $issueId = (int)$issueId;
         if ($issueId < 1) {
             throw new UnableToLinkException(
                 '"' . $linkDetails['value'] . '" is not a valid Github issue number.',

--- a/Classes/LinkHandler/GithubLinkBuilder.php
+++ b/Classes/LinkHandler/GithubLinkBuilder.php
@@ -45,7 +45,7 @@ class GithubLinkBuilder extends AbstractTypolinkBuilder
         $issueId = (int)$issueId;
         if ($issueId < 1) {
             throw new UnableToLinkException(
-                '"' . $linkDetails['value'] . '" is not a valid Github issue number.',
+                '"' . $linkDetails['value'] . '" is not a valid GitHub issue number.',
                 // Use the Unix timestamp of the time of creation of this message
                 1665304602,
                 null,

--- a/Classes/LinkHandler/GithubLinkBuilder.php
+++ b/Classes/LinkHandler/GithubLinkBuilder.php
@@ -29,9 +29,6 @@ class GithubLinkBuilder extends AbstractTypolinkBuilder
 {
     const TYPE_GITHUB = 'github';
 
-    /**
-     * @inheritdoc
-     */
     public function build(
         array &$linkDetails,
         string $linkText,

--- a/Classes/LinkHandler/GithubLinkBuilder.php
+++ b/Classes/LinkHandler/GithubLinkBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace T3docs\Examples\LinkHandler;
+
+use TYPO3\CMS\Core\LinkHandling\LinkService;
+use TYPO3\CMS\Frontend\Typolink\AbstractTypolinkBuilder;
+use TYPO3\CMS\Frontend\Typolink\LinkResult;
+use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
+use TYPO3\CMS\Frontend\Typolink\UnableToLinkException;
+
+/**
+ * Builds a TypoLink to a Github issue
+ */
+class GithubLinkBuilder extends AbstractTypolinkBuilder
+{
+    const TYPE_GITHUB = 'github';
+
+    /**
+     * @inheritdoc
+     */
+    public function build(
+        array &$linkDetails,
+        string $linkText,
+        string $target,
+        array $conf
+    ): LinkResultInterface {
+        $issueId = trim($linkDetails['value']);
+        if (str_starts_with($issueId, '#')) {
+            $issueId = substr($issueId, 1);
+        }
+        $issueId = (int) $issueId;
+        if ($issueId < 1) {
+            throw new UnableToLinkException(
+                '"' . $linkDetails['value'] . '" is not a valid Github issue number.',
+                // Use the Unix timestamp of the time of creation of this message
+                1665304602,
+                null,
+                $linkText
+            );
+        }
+        $url = 'https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/' . $issueId;
+
+        return (new LinkResult(self::TYPE_GITHUB, $url))
+            ->withTarget($target)
+            ->withLinkConfiguration($conf)
+            ->withLinkText($linkText);
+    }
+}

--- a/Configuration/TsConfig/Page/Extension/Linkhandler.tsconfig
+++ b/Configuration/TsConfig/Page/Extension/Linkhandler.tsconfig
@@ -9,7 +9,7 @@ TCEMAIN.linkHandler {
       scanBefore = page
    }
    github {
-      handler = T3docs\\Examples\\LinkHandler\\GitHubLinkHandler
+      handler = T3docs\Examples\LinkHandler\GitHubLinkHandler
       label = LLL:EXT:examples/Resources/Private/Language/locallang_browse_links.xlf:github
       displayAfter = haiku
       scanBefore = url

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -39,6 +39,9 @@ defined('TYPO3') or die();
         'class' => \T3docs\Examples\Form\Element\SpecialFieldElement::class,
     ];
 
+    $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['github'] =
+        \T3docs\Examples\LinkHandler\GithubLinkBuilder::class;
+
     // Add example configuration for the logging API
     $GLOBALS['TYPO3_CONF_VARS']['LOG']['T3docs']['Examples']['Controller']['writerConfiguration'] = [
         // configuration for ERROR level log entries


### PR DESCRIPTION
Forward port from https://github.com/TYPO3-Documentation/t3docs-examples/pull/132

The TypolinkBuilder was missing all together. This example can never have worked as in promised in the docs

releases: main