### PR TITLE
[BUGFIX] Require linkvalidator in v11-compatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "require": {
         "typo3/cms-core": "^11.5.0",
-		"typo3/cms-fluid-styled-content": "^11.5.0"
+		"typo3/cms-fluid-styled-content": "^11.5.0",
+		"typo3/cms-linkvalidator": "^11.5.0"
     },
     "replace": {
         "typo3-ter/examples": "self.version"
@@ -37,5 +38,11 @@
             "rm .gitignore",
             "rm .editorconfig"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
+        }
     }
 }


### PR DESCRIPTION
This avoids an error on a TYPO3 installation without installed linkvalidator on DI compile time:

Cannot autowire service "T3docs\Examples\EventListener\LinkValidator\CheckExternalLinksToLocalPagesEventListener": argument "$brokenLinkRepository" of method "__construct()" has type "TYPO3\CMS\Linkvalidator\Repository\BrokenLinkRepository" but this class was not found.

Additionally, allow composer plugins.