### PR TITLE
[FEATURE] Improve the record link browser example

### DIFF
--- a/Configuration/TsConfig/Page/Extension/Linkhandler.tsconfig
+++ b/Configuration/TsConfig/Page/Extension/Linkhandler.tsconfig
@@ -1,13 +1,4 @@
 TCEMAIN.linkHandler {
-   haiku {
-      handler = TYPO3\CMS\Recordlist\LinkHandler\RecordLinkHandler
-      label = LLL:EXT:examples/Resources/Private/Language/locallang_browse_links.xlf:haiku
-      configuration {
-         table = tx_examples_haiku
-      }
-      displayAfter = url
-      scanBefore = page
-   }
    github {
       handler = T3docs\Examples\LinkHandler\GitHubLinkHandler
       label = LLL:EXT:examples/Resources/Private/Language/locallang_browse_links.xlf:github

--- a/Configuration/TsConfig/Page/LinkBrowser/HaikuRecordLinkBrowser.tsconfig
+++ b/Configuration/TsConfig/Page/LinkBrowser/HaikuRecordLinkBrowser.tsconfig
@@ -1,0 +1,11 @@
+TCEMAIN.linkHandler {
+    haiku {
+        handler = TYPO3\CMS\Recordlist\LinkHandler\RecordLinkHandler
+        label = LLL:EXT:examples/Resources/Private/Language/locallang_browse_links.xlf:haiku
+        configuration {
+            table = tx_examples_haiku
+        }
+        displayAfter = url
+        scanBefore = page
+    }
+}

--- a/Configuration/TypoScript/PluginHaiku/constants.typoscript
+++ b/Configuration/TypoScript/PluginHaiku/constants.typoscript
@@ -6,7 +6,9 @@ plugin.tx_examples_haiku {
         layoutRootPath = EXT:examples/Resources/Private/Templates
     }
     settings {
+        # cat=examples//b; type=int+; label=Haiku Single pid: The id of the page where the haiku detail view should be displayed
         singlePid = 0
+        # cat=examples//c; type=int+; label=Haiku list pid: The id of the page where list of haikus is displayed.
         listPid = 0
     }
 }

--- a/Configuration/TypoScript/RecordLinks/Haiku.typoscript
+++ b/Configuration/TypoScript/RecordLinks/Haiku.typoscript
@@ -3,9 +3,8 @@ config.recordLinks.haiku {
    forceLink = 0
 
    typolink {
-      parameter = 1
+      parameter = {$plugin.tx_examples_haiku.settings.singlePid}
       additionalParams.data = field:uid
-      additionalParams.wrap = &tx_example_pi1[haiku]=|
-      useCacheHash = 1
+      additionalParams.wrap = &tx_examples_haiku[action]=show&tx_examples_haiku[haiku]=|
    }
 }

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,3 +1,4 @@
 @import 'EXT:examples/Configuration/TsConfig/Page/*.tsconfig'
+@import 'EXT:examples/Configuration/TsConfig/Page/LinkBrowser/*.tsconfig'
 @import 'EXT:examples/Configuration/TsConfig/Page/Extension/*.tsconfig'
 @import 'EXT:examples/Configuration/TsConfig/Page/Mod/*.tsconfig'


### PR DESCRIPTION
Isolate the record link TSconfig to its own file as it is easier to display and link to in the documentation. Move the TSconfig from "Extension" as the link browser is part of typo3/cms-backend and an integral part of the TYPO3 Core.

Adjust the TypoScript so the Haiku Detail view links to the detail view of our non-Extbase Plugin example.

On the fly: Add comment-editor comments to the Haiku Plugin constants.

The custom github linkhandler TSconfig will be moved in a follow-up