### PR TITLE
[TASK] Add missing header comments to PHP files

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,4 +5,21 @@ $config
     ->getFinder()->in(__DIR__)
 ;
 
+$header = <<<EOF
+This file is part of the TYPO3 CMS project.
+
+It is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License, either version 2
+of the License, or any later version.
+
+For the full copyright and license information, please read the
+LICENSE.txt file that was distributed with this source code.
+
+The TYPO3 project - inspiring people to share!
+EOF;
+
+$config->addRules([
+    'header_comment' => ['header' => $header, 'separate' => 'both'],
+]);
+
 return $config;

--- a/Classes/Command/CreateWizardCommand.php
+++ b/Classes/Command/CreateWizardCommand.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Command;
 
 use Symfony\Component\Console\Command\Command;

--- a/Classes/Command/DoSomethingCommand.php
+++ b/Classes/Command/DoSomethingCommand.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Command;
 
 use Symfony\Component\Console\Command\Command;

--- a/Classes/Command/MeowInformationCommand.php
+++ b/Classes/Command/MeowInformationCommand.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Command;
 
 use Symfony\Component\Console\Command\Command;

--- a/Classes/ContextMenu/HelloWorldItemProvider.php
+++ b/Classes/ContextMenu/HelloWorldItemProvider.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace T3docs\Examples\ContextMenu;
-
-/**
+/*
  * This file is part of the TYPO3 CMS project.
  *
  * It is free software; you can redistribute it and/or modify it under
@@ -14,6 +12,8 @@ namespace T3docs\Examples\ContextMenu;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
+namespace T3docs\Examples\ContextMenu;
 
 use TYPO3\CMS\Backend\ContextMenu\ItemProviders\AbstractProvider;
 

--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Controller;
 
 use Psr\Http\Message\ResponseInterface;

--- a/Classes/Controller/ErrorController.php
+++ b/Classes/Controller/ErrorController.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace T3docs\Examples\Controller;
-
-/**
+/*
  * This file is part of the TYPO3 CMS project.
  *
  * It is free software; you can redistribute it and/or modify it under
@@ -14,6 +12,8 @@ namespace T3docs\Examples\Controller;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
+namespace T3docs\Examples\Controller;
 
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;

--- a/Classes/Controller/FalExampleController.php
+++ b/Classes/Controller/FalExampleController.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace T3docs\Examples\Controller;
-
 /*
  * This file is part of the TYPO3 CMS project.
  *
@@ -14,6 +12,8 @@ namespace T3docs\Examples\Controller;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
+namespace T3docs\Examples\Controller;
 
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Resource\ResourceFactory;

--- a/Classes/Controller/Haiku/DetailController.php
+++ b/Classes/Controller/Haiku/DetailController.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Controller\Haiku;
 
 use Psr\Http\Message\ServerRequestInterface;

--- a/Classes/Controller/Haiku/ListController.php
+++ b/Classes/Controller/Haiku/ListController.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Controller\Haiku;
 
 use Psr\Http\Message\ServerRequestInterface;

--- a/Classes/Controller/HtmlParserController.php
+++ b/Classes/Controller/HtmlParserController.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace T3docs\Examples\Controller;
-
-/**
+/*
  * This file is part of the TYPO3 CMS project.
  *
  * It is free software; you can redistribute it and/or modify it under
@@ -14,6 +12,8 @@ namespace T3docs\Examples\Controller;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
+namespace T3docs\Examples\Controller;
 
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Html\HtmlParser;

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace T3docs\Examples\Controller;
-
-/**
+/*
  * This file is part of the TYPO3 CMS project.
  *
  * It is free software; you can redistribute it and/or modify it under
@@ -14,6 +12,8 @@ namespace T3docs\Examples\Controller;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
+namespace T3docs\Examples\Controller;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/Classes/DataProcessing/CustomCategoryProcessor.php
+++ b/Classes/DataProcessing/CustomCategoryProcessor.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace T3docs\Examples\DataProcessing;
-
 /*
  * This file is part of the TYPO3 CMS project.
  *
@@ -16,6 +14,8 @@ namespace T3docs\Examples\DataProcessing;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
+namespace T3docs\Examples\DataProcessing;
 
 use T3docs\Examples\Domain\Repository\CategoryRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Classes/Domain/Repository/HaikuRepository.php
+++ b/Classes/Domain/Repository/HaikuRepository.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Domain\Repository;
 
 use T3docs\Examples\Exception\NoSuchHaikuException;

--- a/Classes/EventListener/Core/Configuration/FlexFormParsingModifyEventListener.php
+++ b/Classes/EventListener/Core/Configuration/FlexFormParsingModifyEventListener.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\EventListener\Core\Configuration;
 
 use TYPO3\CMS\Core\Configuration\Event\AfterFlexFormDataStructureIdentifierInitializedEvent;

--- a/Classes/EventListener/LinkValidator/CheckExternalLinksToLocalPagesEventListener.php
+++ b/Classes/EventListener/LinkValidator/CheckExternalLinksToLocalPagesEventListener.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\EventListener\LinkValidator;
 
 use TYPO3\CMS\Core\DataHandling\SoftReference\SoftReferenceParserFactory;

--- a/Classes/Exception/InvalidWizardException.php
+++ b/Classes/Exception/InvalidWizardException.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Exception;
 
 /**

--- a/Classes/Exception/NoSuchHaikuException.php
+++ b/Classes/Exception/NoSuchHaikuException.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Exception;
 
 /**

--- a/Classes/Form/Element/SpecialFieldElement.php
+++ b/Classes/Form/Element/SpecialFieldElement.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Form\Element;
 
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Http;
 
 use TYPO3\CMS\Core\Http\RequestFactory;

--- a/Classes/LinkHandler/GitHubLinkHandler.php
+++ b/Classes/LinkHandler/GitHubLinkHandler.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace T3docs\Examples\LinkHandler;
-
-/**
+/*
  * This file is part of the TYPO3 CMS project.
  *
  * It is free software; you can redistribute it and/or modify it under
@@ -14,6 +12,8 @@ namespace T3docs\Examples\LinkHandler;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
+namespace T3docs\Examples\LinkHandler;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Controller\AbstractLinkBrowserController;

--- a/Classes/LinkValidator/LinkType/ExampleLinkType.php
+++ b/Classes/LinkValidator/LinkType/ExampleLinkType.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace T3docs\Examples\LinkValidator\LinkType;
-
-/**
+/*
  * This file is part of the TYPO3 CMS project.
  *
  * It is free software; you can redistribute it and/or modify it under
@@ -14,6 +12,8 @@ namespace T3docs\Examples\LinkValidator\LinkType;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
+namespace T3docs\Examples\LinkValidator\LinkType;
 
 use TYPO3\CMS\Linkvalidator\Linktype\AbstractLinktype;
 

--- a/Classes/Service/FlexFormSettingsService.php
+++ b/Classes/Service/FlexFormSettingsService.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Service;
 
 use TYPO3\CMS\Core\Service\FlexFormService;

--- a/Classes/Service/StandaloneViewService.php
+++ b/Classes/Service/StandaloneViewService.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Service;
 
 use Psr\Http\Message\ServerRequestInterface;

--- a/Classes/Service/TableInformationService.php
+++ b/Classes/Service/TableInformationService.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Service;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;

--- a/Classes/Userfuncs/CustomMenu.php
+++ b/Classes/Userfuncs/CustomMenu.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 namespace T3docs\Examples\Userfuncs;
 
 class CustomMenu

--- a/Classes/Userfuncs/Tca.php
+++ b/Classes/Userfuncs/Tca.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace T3docs\Examples\Userfuncs;
-
-/**
+/*
  * This file is part of the TYPO3 CMS project.
  *
  * It is free software; you can redistribute it and/or modify it under
@@ -14,6 +12,8 @@ namespace T3docs\Examples\Userfuncs;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
+namespace T3docs\Examples\Userfuncs;
 
 use TYPO3\CMS\Backend\Form\Element\UserElement;
 use TYPO3\CMS\Backend\Utility\BackendUtility;

--- a/Classes/Xclass/NewRecordController.php
+++ b/Classes/Xclass/NewRecordController.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace T3docs\Examples\Xclass;
-
-/**
+/*
  * This file is part of the TYPO3 CMS project.
  *
  * It is free software; you can redistribute it and/or modify it under
@@ -14,6 +12,8 @@ namespace T3docs\Examples\Xclass;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
+namespace T3docs\Examples\Xclass;
 
 /**
  * This class XCLASSes NewRecordController to modify the layout of the New Record Wizard

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 return [
     'tx_examples_count' => [
         'path' => '/examples/module/count',

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 use T3docs\Examples\Controller\AdminModuleController;
 use T3docs\Examples\Controller\ModuleController;
 

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 return [
     \T3docs\Examples\Domain\Model\Category::class => [
         'tableName' => 'sys_category',

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
 
 return [

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 return [
     'dependencies' => ['core', 'backend'],
     'tags' => [

--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 $tempColumnsBackend = [

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 // Add some fields to FE Users table to show TCA fields definitions

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 // Add a "related pages" field to demonstrate select-type fields with tree rendering

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 // Declare static TypoScript files

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;

--- a/Configuration/TCA/Overrides/tt_content_plugin_haiku_detail.php
+++ b/Configuration/TCA/Overrides/tt_content_plugin_haiku_detail.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(

--- a/Configuration/TCA/Overrides/tt_content_plugin_haiku_list.php
+++ b/Configuration/TCA/Overrides/tt_content_plugin_haiku_list.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(

--- a/Configuration/TCA/Overrides/tt_content_plugin_htmlparser.php
+++ b/Configuration/TCA/Overrides/tt_content_plugin_htmlparser.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;

--- a/Configuration/TCA/Overrides/tt_content_plugin_pi1.php
+++ b/Configuration/TCA/Overrides/tt_content_plugin_pi1.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;

--- a/Configuration/TCA/tx_examples_dummy.php
+++ b/Configuration/TCA/tx_examples_dummy.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 return [
     'ctrl' => [
         'title' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tx_examples_dummy',

--- a/Configuration/TCA/tx_examples_haiku.php
+++ b/Configuration/TCA/tx_examples_haiku.php
@@ -1,5 +1,18 @@
 <?php
 
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 return [
     'ctrl' => [
         'title' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tx_examples_haiku',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,14 +1,17 @@
 <?php
 
-/***************************************************************
- * Extension Manager/Repository config file for ext "examples".
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- * Auto generated 23-11-2016 20:16
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * Manual updates:
- * Only the data in the array - everything else is removed by next
- * writing. "version" and "dependencies" must not be touched!
- ***************************************************************/
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
 
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Core Documentation Code Examples',

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,18 @@
 <?php
 
-// Prevent Script from being called directly
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 // encapsulate all locally defined variables

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,6 +1,18 @@
 <?php
 
-// Prevent Script from being called directly
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 defined('TYPO3') or die();
 
 // encapsulate all locally defined variables


### PR DESCRIPTION
This is now configured for php-cs-fixer, so every usage of "composer fix:php:cs" will check for the header comment and add it if not available.

Beware: Code snippets highlighting lines may have to change line numbers accordingly.