### PR TITLE
[CI] Split up workflows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -80,5 +80,5 @@ indent_style = tab
 indent_size = 2
 
 # YAML-Files
-[*.yaml]
+[{*.yaml, *.yml}]
 indent_size = 2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,43 +1,43 @@
 name: tests
 
 on:
-    push:
-    pull_request:
+  push:
+  pull_request:
 
 jobs:
-    lint:
-        name: Linting
-        runs-on: ubuntu-22.04
-        strategy:
-            matrix:
-                php:
-                    - '8.1'
-                    - '8.2'
-        steps:
-            -   name: Checkout
-                uses: actions/checkout@v3
+  lint:
+    name: Linting
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        php:
+          - '8.1'
+          - '8.2'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-            -   name: Lint PHP
-                run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+      - name: Lint PHP
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
-    code-quality:
-        name: Code Quality
-        runs-on: ubuntu-22.04
-        env:
-            php: '8.1'
+  code-quality:
+    name: Code Quality
+    runs-on: ubuntu-22.04
+    env:
+      php: '8.1'
 
-        steps:
-            -   name: Checkout
-                uses: actions/checkout@v3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-            -   name: Install testing system
-                run: Build/Scripts/runTests.sh -p ${{ php }} -s composerUpdate
+      - name: Install testing system
+        run: Build/Scripts/runTests.sh -p ${{ php }} -s composerUpdate
 
-            -   name: Composer validate
-                run: Build/Scripts/runTests.sh -p ${{ php }} -s composerValidate
+      - name: Composer validate
+        run: Build/Scripts/runTests.sh -p ${{ php }} -s composerValidate
 
-            -   name: Composer normalize
-                run: Build/Scripts/runTests.sh -p ${{ php }} -s composerNormalize -n
+      - name: Composer normalize
+        run: Build/Scripts/runTests.sh -p ${{ php }} -s composerNormalize -n
 
-            -   name: CGL
-                run: Build/Scripts/runTests.sh -n -p ${{ php }} -s cgl
+      - name: CGL
+        run: Build/Scripts/runTests.sh -n -p ${{ php }} -s cgl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,20 +24,20 @@ jobs:
     name: Code Quality
     runs-on: ubuntu-22.04
     env:
-      php: '8.1'
+      PHP: '8.1'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install testing system
-        run: Build/Scripts/runTests.sh -p ${{ php }} -s composerUpdate
+        run: Build/Scripts/runTests.sh -p ${{ PHP }} -s composerUpdate
 
       - name: Composer validate
-        run: Build/Scripts/runTests.sh -p ${{ php }} -s composerValidate
+        run: Build/Scripts/runTests.sh -p ${{ PHP }} -s composerValidate
 
       - name: Composer normalize
-        run: Build/Scripts/runTests.sh -p ${{ php }} -s composerNormalize -n
+        run: Build/Scripts/runTests.sh -p ${{ PHP }} -s composerNormalize -n
 
       - name: CGL
-        run: Build/Scripts/runTests.sh -n -p ${{ php }} -s cgl
+        run: Build/Scripts/runTests.sh -n -p ${{ PHP }} -s cgl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,34 +1,43 @@
 name: tests
 
 on:
-   push:
-   pull_request:
+    push:
+    pull_request:
 
 jobs:
-   testsuite:
-      name: All tests
-      runs-on: ubuntu-22.04
-      strategy:
-         matrix:
-            php:
-               - '8.1'
-               - '8.2'
-      steps:
-         - name: Checkout
-           uses: actions/checkout@v3
+    lint:
+        name: Linting
+        runs-on: ubuntu-22.04
+        strategy:
+            matrix:
+                php:
+                    - '8.1'
+                    - '8.2'
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v3
 
-         - name: Install testing system
-           run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate
+            -   name: Lint PHP
+                run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
-         - name: Composer validate
-           run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate
+    code-quality:
+        name: Code Quality
+        runs-on: ubuntu-22.04
+        env:
+            php: '8.1'
 
-         - name: Composer normalize
-           run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerNormalize -n
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v3
 
-         - name: Lint PHP
-           run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+            -   name: Install testing system
+                run: Build/Scripts/runTests.sh -p ${{ php }} -s composerUpdate
 
-         - name: CGL
-           if: ${{ matrix.php == '8.1' }}
-           run: Build/Scripts/runTests.sh -n -p ${{ matrix.php }} -s cgl
+            -   name: Composer validate
+                run: Build/Scripts/runTests.sh -p ${{ php }} -s composerValidate
+
+            -   name: Composer normalize
+                run: Build/Scripts/runTests.sh -p ${{ php }} -s composerNormalize -n
+
+            -   name: CGL
+                run: Build/Scripts/runTests.sh -n -p ${{ php }} -s cgl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install testing system
-        run: Build/Scripts/runTests.sh -p ${{ PHP }} -s composerUpdate
+        run: Build/Scripts/runTests.sh -p ${{ $PHP }} -s composerUpdate
 
       - name: Composer validate
-        run: Build/Scripts/runTests.sh -p ${{ PHP }} -s composerValidate
+        run: Build/Scripts/runTests.sh -p ${{ $PHP }} -s composerValidate
 
       - name: Composer normalize
-        run: Build/Scripts/runTests.sh -p ${{ PHP }} -s composerNormalize -n
+        run: Build/Scripts/runTests.sh -p ${{ $PHP }} -s composerNormalize -n
 
       - name: CGL
-        run: Build/Scripts/runTests.sh -n -p ${{ PHP }} -s cgl
+        run: Build/Scripts/runTests.sh -n -p ${{ $PHP }} -s cgl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,20 +24,20 @@ jobs:
     name: Code Quality
     runs-on: ubuntu-22.04
     env:
-      PHP: '8.1'
+      php: '8.1'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install testing system
-        run: Build/Scripts/runTests.sh -p ${{ env.PHP }} -s composerUpdate
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerUpdate
 
       - name: Composer validate
-        run: Build/Scripts/runTests.sh -p ${{ env.PHP }} -s composerValidate
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerValidate
 
       - name: Composer normalize
-        run: Build/Scripts/runTests.sh -p ${{ env.PHP }} -s composerNormalize -n
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerNormalize -n
 
       - name: CGL
-        run: Build/Scripts/runTests.sh -n -p ${{ env.PHP }} -s cgl
+        run: Build/Scripts/runTests.sh -n -p ${{ env.php }} -s cgl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install testing system
-        run: Build/Scripts/runTests.sh -p ${{ $PHP }} -s composerUpdate
+        run: Build/Scripts/runTests.sh -p ${{ env.PHP }} -s composerUpdate
 
       - name: Composer validate
-        run: Build/Scripts/runTests.sh -p ${{ $PHP }} -s composerValidate
+        run: Build/Scripts/runTests.sh -p ${{ env.PHP }} -s composerValidate
 
       - name: Composer normalize
-        run: Build/Scripts/runTests.sh -p ${{ $PHP }} -s composerNormalize -n
+        run: Build/Scripts/runTests.sh -p ${{ env.PHP }} -s composerNormalize -n
 
       - name: CGL
-        run: Build/Scripts/runTests.sh -n -p ${{ $PHP }} -s cgl
+        run: Build/Scripts/runTests.sh -n -p ${{ env.PHP }} -s cgl


### PR DESCRIPTION
We currently only need to run the linting on the supported PHP versions.
Checking the normalization of composer.json file or if the code styles 
are applied well can be done in one PHP version only. 
This saves resources and keeps the workflow slim.