### PR TITLE
[TASK] Convert XLIFF files to version 1.2

### DIFF
--- a/Resources/Private/Language/AdminModule/locallang_mod.xlf
+++ b/Resources/Private/Language/AdminModule/locallang_mod.xlf
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" datatype="plaintext" original="EXT:examples/Resources/Private/Language/Module/locallang_mod.xlf" date="2021-02-13T10:49:34Z" product-name="examples">
-		<header/>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" original="EXT:examples/Resources/Private/Language/Module/locallang_mod.xlf" datatype="plaintext" product-name="examples" date="2022-10-20T18:44:02+02:00">
+		<header></header>
 		<body>
-			<trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
-				<source>Admin Example</source>
-			</trans-unit>
 			<trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
 				<source>Example Admin module showing some Core functionality</source>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
+				<source>Admin Example</source>
 			</trans-unit>
 			<trans-unit id="mlang_tabs_tab" resname="mlang_tabs_tab">
 				<source>Example Admin module</source>

--- a/Resources/Private/Language/Module/locallang.xlf
+++ b/Resources/Private/Language/Module/locallang.xlf
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" datatype="plaintext" original="EXT:examples/Resources/Private/Language/Module/locallang.xlf" date="2021-02-13T10:49:35Z" product-name="examples">
-		<header/>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" original="EXT:examples/Resources/Private/Language/Module/locallang.xlf" datatype="plaintext" product-name="examples" date="2022-10-20T18:43:41+02:00">
+		<header></header>
 		<body>
 			<trans-unit id="examples" resname="examples">
 				<source>Examples</source>
 			</trans-unit>
-			<trans-unit id="module.menu.flash" resname="module.menu.flash">
-				<source>Flash queue</source>
-			</trans-unit>
-			<trans-unit id="module.menu.log" resname="module.menu.log">
-				<source>Make log entries</source>
-			</trans-unit>
-			<trans-unit id="module.menu.tree" resname="module.menu.tree">
-				<source>Display a tree</source>
-			</trans-unit>
 			<trans-unit id="module.menu.clipboard" resname="module.menu.clipboard">
 				<source>Clipboard</source>
 			</trans-unit>
-			<trans-unit id="module.menu.password" resname="module.menu.password">
-				<source>Check Passwords</source>
+			<trans-unit id="module.menu.fileReference" resname="module.menu.fileReference">
+				<source>File References</source>
+			</trans-unit>
+			<trans-unit id="module.menu.flash" resname="module.menu.flash">
+				<source>Flash queue</source>
 			</trans-unit>
 			<trans-unit id="module.menu.links" resname="module.menu.links">
 				<source>Links</source>
 			</trans-unit>
-			<trans-unit id="module.menu.fileReference" resname="module.menu.fileReference">
-				<source>File References</source>
+			<trans-unit id="module.menu.log" resname="module.menu.log">
+				<source>Make log entries</source>
+			</trans-unit>
+			<trans-unit id="module.menu.password" resname="module.menu.password">
+				<source>Check Passwords</source>
+			</trans-unit>
+			<trans-unit id="module.menu.tree" resname="module.menu.tree">
+				<source>Display a tree</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/Module/locallang_mod.xlf
+++ b/Resources/Private/Language/Module/locallang_mod.xlf
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" datatype="plaintext" original="EXT:examples/Resources/Private/Language/Module/locallang_mod.xlf" date="2021-02-13T10:49:34Z" product-name="examples">
-		<header/>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" original="EXT:examples/Resources/Private/Language/Module/locallang_mod.xlf" datatype="plaintext" product-name="examples" date="2022-10-20T18:43:50+02:00">
+		<header></header>
 		<body>
-			<trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
-				<source>Example</source>
-			</trans-unit>
 			<trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
 				<source>Example module showing some Core functionality</source>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
+				<source>Example</source>
 			</trans-unit>
 			<trans-unit id="mlang_tabs_tab" resname="mlang_tabs_tab">
 				<source>Example module</source>

--- a/Resources/Private/Language/PluginHaiku/de.locallang.xlf
+++ b/Resources/Private/Language/PluginHaiku/de.locallang.xlf
@@ -1,31 +1,31 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-	<file source-language="en" datatype="plaintext" original="messages" date="2022-09-18T18:44:59Z" product-name="examples">
-		<header/>
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" target-language="de" original="messages" datatype="plaintext" product-name="examples" date="2022-10-20T18:43:14+02:00">
+		<header></header>
 		<body>
-			<trans-unit id="button.backToList" approved="yes">
+			<trans-unit id="button.backToList" resname="button.backToList">
 				<source>Back to list</source>
 				<target>Zurück zur Übersicht</target>
 			</trans-unit>
-			<trans-unit id="season.spring" approved="yes">
-				<source>spring</source>
-				<target>Frühling</target>
-			</trans-unit>
-			<trans-unit id="season.summer" approved="yes">
-				<source>summer</source>
-				<target>Sommer</target>
-			</trans-unit>
-			<trans-unit id="season.autumn" approved="yes">
+			<trans-unit id="season.autumn" resname="season.autumn">
 				<source>autumn</source>
 				<target>Herbst</target>
 			</trans-unit>
-			<trans-unit id="season.winter" approved="yes">
-				<source>winter</source>
-				<target>Winter</target>
+			<trans-unit id="season.spring" resname="season.spring">
+				<source>spring</source>
+				<target>Frühling</target>
 			</trans-unit>
-			<trans-unit id="season.theFifthSeason" approved="yes">
+			<trans-unit id="season.summer" resname="season.summer">
+				<source>summer</source>
+				<target>Sommer</target>
+			</trans-unit>
+			<trans-unit id="season.theFifthSeason" resname="season.theFifthSeason">
 				<source>Carnival</source>
 				<target>Fastnacht</target>
+			</trans-unit>
+			<trans-unit id="season.winter" resname="season.winter">
+				<source>winter</source>
+				<target>Winter</target>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/PluginHaiku/locallang.xlf
+++ b/Resources/Private/Language/PluginHaiku/locallang.xlf
@@ -1,25 +1,25 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-	<file source-language="en" datatype="plaintext" original="messages" date="2022-09-18T18:44:59Z" product-name="examples">
-		<header/>
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" original="messages" datatype="plaintext" product-name="examples" date="2022-10-20T18:43:14+02:00">
+		<header></header>
 		<body>
-			<trans-unit id="button.backToList" xml:space="preserve">
+			<trans-unit id="button.backToList" resname="button.backToList">
 				<source>Back to list</source>
 			</trans-unit>
-			<trans-unit id="season.spring" xml:space="preserve">
-				<source>spring</source>
-			</trans-unit>
-			<trans-unit id="season.summer" xml:space="preserve">
-				<source>summer</source>
-			</trans-unit>
-			<trans-unit id="season.autumn" xml:space="preserve">
+			<trans-unit id="season.autumn" resname="season.autumn">
 				<source>autumn</source>
 			</trans-unit>
-			<trans-unit id="season.winter" xml:space="preserve">
-				<source>winter</source>
+			<trans-unit id="season.spring" resname="season.spring">
+				<source>spring</source>
 			</trans-unit>
-			<trans-unit id="season.theFifthSeason" xml:space="preserve">
+			<trans-unit id="season.summer" resname="season.summer">
+				<source>summer</source>
+			</trans-unit>
+			<trans-unit id="season.theFifthSeason" resname="season.theFifthSeason">
 				<source>Carnival</source>
+			</trans-unit>
+			<trans-unit id="season.winter" resname="season.winter">
+				<source>winter</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/PluginHaiku/locallang_db.xlf
+++ b/Resources/Private/Language/PluginHaiku/locallang_db.xlf
@@ -1,25 +1,25 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-	<file source-language="en" datatype="plaintext" original="messages" date="2022-09-18T18:44:59Z" product-name="examples">
-		<header/>
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" original="messages" datatype="plaintext" product-name="examples" date="2022-10-20T18:43:25+02:00">
+		<header></header>
 		<body>
-			<trans-unit id="list.title" xml:space="preserve">
-				<source>Haiku poem list</source>
-			</trans-unit>
-			<trans-unit id="list.description" xml:space="preserve">
-				<source>Displays a list of haiku poems.</source>
-			</trans-unit>
-			<trans-unit id="detail.title" xml:space="preserve">
-				<source>Haiku poem detail</source>
-			</trans-unit>
-			<trans-unit id="detail.description" xml:space="preserve">
+			<trans-unit id="detail.description" resname="detail.description">
 				<source>Displays a haiku poem in detail.</source>
 			</trans-unit>
-			<trans-unit id="singlePageUid" xml:space="preserve">
-				<source>Page to display detail view</source>
+			<trans-unit id="detail.title" resname="detail.title">
+				<source>Haiku poem detail</source>
 			</trans-unit>
-			<trans-unit id="listPageUid" xml:space="preserve">
-				<source>Page for "Back to list" link</source>
+			<trans-unit id="list.description" resname="list.description">
+				<source>Displays a list of haiku poems.</source>
+			</trans-unit>
+			<trans-unit id="list.title" resname="list.title">
+				<source>Haiku poem list</source>
+			</trans-unit>
+			<trans-unit id="listPageUid" resname="listPageUid">
+				<source>Page for &#34;Back to list&#34; link</source>
+			</trans-unit>
+			<trans-unit id="singlePageUid" resname="singlePageUid">
+				<source>Page to display detail view</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/custom.xlf
+++ b/Resources/Private/Language/custom.xlf
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-	<file source-language="en" datatype="plaintext" original="messages" date="2013-03-09T18:44:59Z" product-name="examples">
-		<header/>
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" original="messages" datatype="plaintext" product-name="examples" date="2022-10-20T18:42:36+02:00">
+		<header></header>
 		<body>
-			<trans-unit id="pages.title_formlabel" xml:space="preserve">
+			<trans-unit id="pages.title_formlabel" resname="pages.title_formlabel">
 				<source>Most important tile</source>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Language/de.custom.xlf
+++ b/Resources/Private/Language/de.custom.xlf
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-	<file source-language="en" datatype="plaintext" original="messages" date="2013-03-09T18:44:59Z" product-name="examples">
-		<header/>
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" target-language="de" original="messages" datatype="plaintext" product-name="examples" date="2022-10-20T18:42:36+02:00">
+		<header></header>
 		<body>
-			<trans-unit id="pages.title_formlabel" xml:space="preserve">
+			<trans-unit id="pages.title_formlabel" resname="pages.title_formlabel">
 				<source>Most important tile</source>
 				<target>Wichtigster Titel</target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,282 +1,274 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-	<file source-language="en" datatype="plaintext" original="messages" date="2013-03-09T18:44:59Z" product-name="examples">
-		<header/>
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" original="messages" datatype="plaintext" product-name="examples" date="2022-10-20T18:41:02+02:00">
+		<header></header>
 		<body>
-			<trans-unit id="mlang_tabs_tab" xml:space="preserve">
-				<source>Examples</source>
-			</trans-unit>
-			<trans-unit id="mlang_labels_tabdescr" xml:space="preserve">
-				<source>Core code examples to demonstrate various features</source>
-			</trans-unit>
-			<trans-unit id="mlang_labels_tablabel" xml:space="preserve">
-				<source>Examples</source>
-			</trans-unit>
-			<trans-unit id="function_flash" xml:space="preserve">
-				<source>Flash messages</source>
-			</trans-unit>
-			<trans-unit id="function_flash_intro" xml:space="preserve">
-				<source>The above demonstrates Flash messages by showing one of each type. They can also come without title.</source>
-			</trans-unit>
-			<trans-unit id="function_flash_javascript" xml:space="preserve">
-				<source>It is also possible to pop flash messages in JavaScript. Click one of the buttons below to see some action.</source>
-			</trans-unit>
-			<trans-unit id="function_flash_javascript_button" xml:space="preserve">
-				<source>Flash message by JavaScript</source>
-			</trans-unit>
-			<trans-unit id="function_flash_javascript_ajax_button" xml:space="preserve">
-				<source>Ajax flash message</source>
-			</trans-unit>
-			<trans-unit id="function_flash_php" xml:space="preserve">
-				<source>The following buttons trigger an Extbase action that forwards to this page and gives a flash message response</source>
-			</trans-unit>
-			<trans-unit id="function_flash_content_elements" xml:space="preserve">
-				<source>Count content elements</source>
-			</trans-unit>
-			<trans-unit id="function_flash_pages" xml:space="preserve">
-				<source>Count pages</source>
-			</trans-unit>
-			<trans-unit id="record_count_title" xml:space="preserve">
-				<source>Record count</source>
-			</trans-unit>
-			<trans-unit id="record_count_message" xml:space="preserve">
-				<source>%s record(s) in table &quot;%s&quot;.</source>
-			</trans-unit>
-			<trans-unit id="function_log" xml:space="preserve">
-				<source>Create log entries</source>
-			</trans-unit>
-			<trans-unit id="function_log_intro" xml:space="preserve">
-				<source>This module creates several log entries every time it is loaded. Click on the button below to reload it and create more entries.</source>
-			</trans-unit>
-			<trans-unit id="function_log_create" xml:space="preserve">
-				<source>Create entries</source>
-			</trans-unit>
-			<trans-unit id="function_tree" xml:space="preserve">
-				<source>Page tree</source>
-			</trans-unit>
-			<trans-unit id="function_tree_intro" xml:space="preserve">
-				<source>This module demonstrates how a page tree can be created and displayed.</source>
-			</trans-unit>
-			<trans-unit id="function_debug" xml:space="preserve">
-				<source>Debug</source>
-			</trans-unit>
-			<trans-unit id="function_debug_intro" xml:space="preserve">
-				<source>This module demonstrates the debug functionality.</source>
-			</trans-unit>
-			<trans-unit id="function_debug_cookies" xml:space="preserve">
-				<source>Debug Cookies</source>
-			</trans-unit>
-			<trans-unit id="function_clipboard" xml:space="preserve">
-				<source>Clipboard</source>
-			</trans-unit>
-			<trans-unit id="function_clipboard_intro" xml:space="preserve">
-				<source>This module displays the content of the clipboard.</source>
-			</trans-unit>
-			<trans-unit id="function_clipboard_current_pad" xml:space="preserve">
-				<source>Current clipboard pad</source>
-			</trans-unit>
-			<trans-unit id="function_clipboard_normal_pad" xml:space="preserve">
-				<source>Normal clipboard pad</source>
-			</trans-unit>
-			<trans-unit id="function_clipboard_files" xml:space="preserve">
-				<source>Files</source>
-			</trans-unit>
-			<trans-unit id="function_clipboard_no_files" xml:space="preserve">
-				<source>No files in this clipboard pad.</source>
-			</trans-unit>
-			<trans-unit id="function_clipboard_pages" xml:space="preserve">
-				<source>Pages</source>
-			</trans-unit>
-			<trans-unit id="function_clipboard_no_pages" xml:space="preserve">
-				<source>No pages in this clipboard pad.</source>
-			</trans-unit>
-			<trans-unit id="function_clipboard_debug" xml:space="preserve">
-				<source>Show in the debug console</source>
-			</trans-unit>
-			<trans-unit id="function_fileReference" xml:space="preserve">
-				<source>File references</source>
-			</trans-unit>
-			<trans-unit id="function_fileReference_intro" xml:space="preserve">
-				<source>This tool demonstrates the creation of File References in the backend. Choose a content element and a file, then click on the "Create relation" button.</source>
-			</trans-unit>
-			<trans-unit id="csm_view_page" xml:space="preserve">
-				<source>View page in tree</source>
-			</trans-unit>
-			<trans-unit id="function_links" xml:space="preserve">
-				<source>Edit links</source>
-			</trans-unit>
-			<trans-unit id="function_links_intro" xml:space="preserve">
-				<source>This module shows how to generate links to edit records or create new ones.</source>
-			</trans-unit>
-			<trans-unit id="function_links_edit_page" xml:space="preserve">
-				<source>Edit page</source>
-			</trans-unit>
-			<trans-unit id="function_links_edit_page_1_restricted" xml:space="preserve">
-				<source>Edit page 1 (only title and hidden fields)</source>
-			</trans-unit>
-			<trans-unit id="function_links_edit_pages_doktype" xml:space="preserve">
-				<source>Edit title and doktype of pages 1 and 2</source>
-			</trans-unit>
-			<trans-unit id="function_links_new_haiku" xml:space="preserve">
-				<source>Create a new haiku (blank)</source>
-			</trans-unit>
-			<trans-unit id="function_links_new_spring_haiku" xml:space="preserve">
-				<source>Create a new haiku for season spring with a predefined title</source>
-			</trans-unit>
-			<trans-unit id="function_links_new_haiku_with_title" xml:space="preserve">
-				<source>Create a new haiku with a predefined title</source>
-			</trans-unit>
-			<trans-unit id="function_links_returnUrl" xml:space="preserve">
-            	<source>with returnUrl to jump back to the module</source>
-            </trans-unit>
-
-			<trans-unit id="function_password" xml:space="preserve">
-				<source>Password hashes</source>
-			</trans-unit>
-			<trans-unit id="function_password_intro" xml:space="preserve">
-				<source>This module demonstrates how to create password
-					hashes and how to test them</source>
-			</trans-unit>
-			<trans-unit id="permissions_header" xml:space="preserve">
-				<source>Custom permissions</source>
-			</trans-unit>
-			<trans-unit id="permissions_option1" xml:space="preserve">
-				<source>Custom permission #1</source>
-			</trans-unit>
-			<trans-unit id="permissions_option1_description" xml:space="preserve">
-				<source>This allows the user to save things.</source>
-			</trans-unit>
-			<trans-unit id="permissions_option2" xml:space="preserve">
-				<source>Custom permission #2</source>
-			</trans-unit>
-			<trans-unit id="permissions_option3" xml:space="preserve">
-				<source>Custom permission #3</source>
-			</trans-unit>
-			<trans-unit id="collections_plugin_title" xml:space="preserve">
-				<source>Examples: Collections usage</source>
-			</trans-unit>
-			<trans-unit id="htmlparser_plugin_title" xml:space="preserve">
-				<source>Examples: HTML parsing</source>
-			</trans-unit>
-			<trans-unit id="falexample_plugin_title" xml:space="preserve">
-				<source>Examples: FAL examples</source>
-			</trans-unit>
-			<trans-unit id="archive_page_type" xml:space="preserve">
-				<source>Archive page</source>
-			</trans-unit>
-			<trans-unit id="additional_categories" xml:space="preserve">
+			<trans-unit id="additional_categories" resname="additional_categories">
 				<source>Additional categories</source>
 			</trans-unit>
-			<trans-unit id="help" xml:space="preserve">
-				<source>HELP</source>
+			<trans-unit id="archive_page_type" resname="archive_page_type">
+				<source>Archive page</source>
 			</trans-unit>
-			<trans-unit id="make_choice" xml:space="preserve">
-				<source>- make a choice!</source>
-			</trans-unit>
-			<trans-unit id="pierror_wizard_title" xml:space="preserve">
-				<source>Error display</source>
-			</trans-unit>
-			<trans-unit id="pierror_wizard_description" xml:space="preserve">
-				<source>Displays error in the frontend to demonstrate error reporting in TYPO3.</source>
-			</trans-unit>
-
-			<!-- New content element example -->
-			<trans-unit id="examples_newcontentelement_title" xml:space="preserve">
-				<source>Example of a custom content element</source>
-			</trans-unit>
-			<trans-unit id="examples_newcontentelement_description" xml:space="preserve">
-				<source>It just displays the content of the field bodytext.</source>
-			</trans-unit>
-
-			<!-- Data processing examples -->
-			<trans-unit id="dataProcessingExamples" xml:space="preserve">
-				<source>DataProcessing examples</source>
-			</trans-unit>
-			<trans-unit id="examples_newcontentcsv_title" xml:space="preserve">
-				<source>CommaSeparatedValueProcessor example</source>
-			</trans-unit>
-			<trans-unit id="examples_newcontentcsv_description" xml:space="preserve">
-				<source>Output comma separated data</source>
-			</trans-unit>
-			<trans-unit id="examples_newcontentcsv_bodytext" xml:space="preserve">
-				<source>Please enter CSV data, separated by Semicolon (';')</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocdb_title" xml:space="preserve">
-				<source>DatabaseQueryProcessor example</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocdb_description" xml:space="preserve">
-				<source>Show list of Haikus </source>
-			</trans-unit>
-			<trans-unit id="examples_dataproclang_title" xml:space="preserve">
-				<source>LanguageMenuProcessor example</source>
-			</trans-unit>
-			<trans-unit id="examples_dataproclang_description" xml:space="preserve">
-				<source>Show languge menu</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocmenu_title" xml:space="preserve">
-				<source>MenuProcessor example</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocmenu_description" xml:space="preserve">
-				<source>Page menu </source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocsite_title" xml:space="preserve">
-				<source>SiteProcessor example</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocsite_description" xml:space="preserve">
-				<source>Show site info</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocsitelanguage_title" xml:space="preserve">
-				<source>SiteLanguageProcessor example</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocsitelanguage_description" xml:space="preserve">
-				<source>Show language info</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocsplit_title" xml:space="preserve">
-				<source>SplitProcessor example</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocsplit_description" xml:space="preserve">
-				<source>Split data </source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocfiles_title" xml:space="preserve">
-				<source>FilesProcessor example</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocfiles_description" xml:space="preserve">
-				<source>Show images</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocgallery_title" xml:space="preserve">
-				<source>GalleryProcessor example</source>
-			</trans-unit>
-			<trans-unit id="examples_dataprocgallery_description" xml:space="preserve">
-				<source>Show images in gallery </source>
-			</trans-unit>
-			<trans-unit id="examples_dataproccustom_title" xml:space="preserve">
-				<source>Custom data processor</source>
-			</trans-unit>
-			<trans-unit id="examples_dataproccustom_description" xml:space="preserve">
-				<source>Show category data</source>
-			</trans-unit>
-
-
-			<trans-unit id="choose_content_element" xml:space="preserve">
+			<trans-unit id="choose_content_element" resname="choose_content_element">
 				<source>Choose a content element</source>
 			</trans-unit>
-			<trans-unit id="choose_file" xml:space="preserve">
+			<trans-unit id="choose_file" resname="choose_file">
 				<source>Choose file</source>
 			</trans-unit>
-			<trans-unit id="create_relation" xml:space="preserve">
+			<trans-unit id="collections_plugin_title" resname="collections_plugin_title">
+				<source>Examples: Collections usage</source>
+			</trans-unit>
+			<trans-unit id="create_relation" resname="create_relation">
 				<source>Create relation</source>
 			</trans-unit>
-			<trans-unit id="create_relation_success" xml:space="preserve">
-				<source>The relation was created successfully.</source>
-			</trans-unit>
-			<trans-unit id="create_relation_error" xml:space="preserve">
+			<trans-unit id="create_relation_error" resname="create_relation_error">
 				<source>Relation creation error</source>
 			</trans-unit>
-			<trans-unit id="new_relation_confirmation" xml:space="preserve">
+			<trans-unit id="create_relation_success" resname="create_relation_success">
+				<source>The relation was created successfully.</source>
+			</trans-unit>
+			<trans-unit id="csm_view_page" resname="csm_view_page">
+				<source>View page in tree</source>
+			</trans-unit>
+			<trans-unit id="dataProcessingExamples" resname="dataProcessingExamples">
+				<source>DataProcessing examples</source>
+			</trans-unit>
+			<trans-unit id="examples_dataproccustom_description" resname="examples_dataproccustom_description">
+				<source>Show category data</source>
+			</trans-unit>
+			<trans-unit id="examples_dataproccustom_title" resname="examples_dataproccustom_title">
+				<source>Custom data processor</source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocdb_description" resname="examples_dataprocdb_description">
+				<source>Show list of Haikus </source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocdb_title" resname="examples_dataprocdb_title">
+				<source>DatabaseQueryProcessor example</source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocfiles_description" resname="examples_dataprocfiles_description">
+				<source>Show images</source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocfiles_title" resname="examples_dataprocfiles_title">
+				<source>FilesProcessor example</source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocgallery_description" resname="examples_dataprocgallery_description">
+				<source>Show images in gallery </source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocgallery_title" resname="examples_dataprocgallery_title">
+				<source>GalleryProcessor example</source>
+			</trans-unit>
+			<trans-unit id="examples_dataproclang_description" resname="examples_dataproclang_description">
+				<source>Show languge menu</source>
+			</trans-unit>
+			<trans-unit id="examples_dataproclang_title" resname="examples_dataproclang_title">
+				<source>LanguageMenuProcessor example</source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocmenu_description" resname="examples_dataprocmenu_description">
+				<source>Page menu </source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocmenu_title" resname="examples_dataprocmenu_title">
+				<source>MenuProcessor example</source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocsite_description" resname="examples_dataprocsite_description">
+				<source>Show site info</source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocsite_title" resname="examples_dataprocsite_title">
+				<source>SiteProcessor example</source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocsitelanguage_description" resname="examples_dataprocsitelanguage_description">
+				<source>Show language info</source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocsitelanguage_title" resname="examples_dataprocsitelanguage_title">
+				<source>SiteLanguageProcessor example</source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocsplit_description" resname="examples_dataprocsplit_description">
+				<source>Split data </source>
+			</trans-unit>
+			<trans-unit id="examples_dataprocsplit_title" resname="examples_dataprocsplit_title">
+				<source>SplitProcessor example</source>
+			</trans-unit>
+			<trans-unit id="examples_newcontentcsv_bodytext" resname="examples_newcontentcsv_bodytext">
+				<source>Please enter CSV data, separated by Semicolon (&#39;;&#39;)</source>
+			</trans-unit>
+			<trans-unit id="examples_newcontentcsv_description" resname="examples_newcontentcsv_description">
+				<source>Output comma separated data</source>
+			</trans-unit>
+			<trans-unit id="examples_newcontentcsv_title" resname="examples_newcontentcsv_title">
+				<source>CommaSeparatedValueProcessor example</source>
+			</trans-unit>
+			<trans-unit id="examples_newcontentelement_description" resname="examples_newcontentelement_description">
+				<source>It just displays the content of the field bodytext.</source>
+			</trans-unit>
+			<trans-unit id="examples_newcontentelement_title" resname="examples_newcontentelement_title">
+				<source>Example of a custom content element</source>
+			</trans-unit>
+			<trans-unit id="falexample_plugin_title" resname="falexample_plugin_title">
+				<source>Examples: FAL examples</source>
+			</trans-unit>
+			<trans-unit id="function_clipboard" resname="function_clipboard">
+				<source>Clipboard</source>
+			</trans-unit>
+			<trans-unit id="function_clipboard_current_pad" resname="function_clipboard_current_pad">
+				<source>Current clipboard pad</source>
+			</trans-unit>
+			<trans-unit id="function_clipboard_debug" resname="function_clipboard_debug">
+				<source>Show in the debug console</source>
+			</trans-unit>
+			<trans-unit id="function_clipboard_files" resname="function_clipboard_files">
+				<source>Files</source>
+			</trans-unit>
+			<trans-unit id="function_clipboard_intro" resname="function_clipboard_intro">
+				<source>This module displays the content of the clipboard.</source>
+			</trans-unit>
+			<trans-unit id="function_clipboard_no_files" resname="function_clipboard_no_files">
+				<source>No files in this clipboard pad.</source>
+			</trans-unit>
+			<trans-unit id="function_clipboard_no_pages" resname="function_clipboard_no_pages">
+				<source>No pages in this clipboard pad.</source>
+			</trans-unit>
+			<trans-unit id="function_clipboard_normal_pad" resname="function_clipboard_normal_pad">
+				<source>Normal clipboard pad</source>
+			</trans-unit>
+			<trans-unit id="function_clipboard_pages" resname="function_clipboard_pages">
+				<source>Pages</source>
+			</trans-unit>
+			<trans-unit id="function_debug" resname="function_debug">
+				<source>Debug</source>
+			</trans-unit>
+			<trans-unit id="function_debug_cookies" resname="function_debug_cookies">
+				<source>Debug Cookies</source>
+			</trans-unit>
+			<trans-unit id="function_debug_intro" resname="function_debug_intro">
+				<source>This module demonstrates the debug functionality.</source>
+			</trans-unit>
+			<trans-unit id="function_fileReference" resname="function_fileReference">
+				<source>File references</source>
+			</trans-unit>
+			<trans-unit id="function_fileReference_intro" resname="function_fileReference_intro">
+				<source>This tool demonstrates the creation of File References in the backend. Choose a content element and a file, then click on the &#34;Create relation&#34; button.</source>
+			</trans-unit>
+			<trans-unit id="function_flash" resname="function_flash">
+				<source>Flash messages</source>
+			</trans-unit>
+			<trans-unit id="function_flash_content_elements" resname="function_flash_content_elements">
+				<source>Count content elements</source>
+			</trans-unit>
+			<trans-unit id="function_flash_intro" resname="function_flash_intro">
+				<source>The above demonstrates Flash messages by showing one of each type. They can also come without title.</source>
+			</trans-unit>
+			<trans-unit id="function_flash_javascript" resname="function_flash_javascript">
+				<source>It is also possible to pop flash messages in JavaScript. Click one of the buttons below to see some action.</source>
+			</trans-unit>
+			<trans-unit id="function_flash_javascript_ajax_button" resname="function_flash_javascript_ajax_button">
+				<source>Ajax flash message</source>
+			</trans-unit>
+			<trans-unit id="function_flash_javascript_button" resname="function_flash_javascript_button">
+				<source>Flash message by JavaScript</source>
+			</trans-unit>
+			<trans-unit id="function_flash_pages" resname="function_flash_pages">
+				<source>Count pages</source>
+			</trans-unit>
+			<trans-unit id="function_flash_php" resname="function_flash_php">
+				<source>The following buttons trigger an Extbase action that forwards to this page and gives a flash message response</source>
+			</trans-unit>
+			<trans-unit id="function_links" resname="function_links">
+				<source>Edit links</source>
+			</trans-unit>
+			<trans-unit id="function_links_edit_page" resname="function_links_edit_page">
+				<source>Edit page</source>
+			</trans-unit>
+			<trans-unit id="function_links_edit_page_1_restricted" resname="function_links_edit_page_1_restricted">
+				<source>Edit page 1 (only title and hidden fields)</source>
+			</trans-unit>
+			<trans-unit id="function_links_edit_pages_doktype" resname="function_links_edit_pages_doktype">
+				<source>Edit title and doktype of pages 1 and 2</source>
+			</trans-unit>
+			<trans-unit id="function_links_intro" resname="function_links_intro">
+				<source>This module shows how to generate links to edit records or create new ones.</source>
+			</trans-unit>
+			<trans-unit id="function_links_new_haiku" resname="function_links_new_haiku">
+				<source>Create a new haiku (blank)</source>
+			</trans-unit>
+			<trans-unit id="function_links_new_haiku_with_title" resname="function_links_new_haiku_with_title">
+				<source>Create a new haiku with a predefined title</source>
+			</trans-unit>
+			<trans-unit id="function_links_new_spring_haiku" resname="function_links_new_spring_haiku">
+				<source>Create a new haiku for season spring with a predefined title</source>
+			</trans-unit>
+			<trans-unit id="function_links_returnUrl" resname="function_links_returnUrl">
+				<source>with returnUrl to jump back to the module</source>
+			</trans-unit>
+			<trans-unit id="function_log" resname="function_log">
+				<source>Create log entries</source>
+			</trans-unit>
+			<trans-unit id="function_log_create" resname="function_log_create">
+				<source>Create entries</source>
+			</trans-unit>
+			<trans-unit id="function_log_intro" resname="function_log_intro">
+				<source>This module creates several log entries every time it is loaded. Click on the button below to reload it and create more entries.</source>
+			</trans-unit>
+			<trans-unit id="function_password" resname="function_password">
+				<source>Password hashes</source>
+			</trans-unit>
+			<trans-unit id="function_password_intro" resname="function_password_intro">
+				<source>This module demonstrates how to create password&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;hashes and how to test them</source>
+			</trans-unit>
+			<trans-unit id="function_tree" resname="function_tree">
+				<source>Page tree</source>
+			</trans-unit>
+			<trans-unit id="function_tree_intro" resname="function_tree_intro">
+				<source>This module demonstrates how a page tree can be created and displayed.</source>
+			</trans-unit>
+			<trans-unit id="help" resname="help">
+				<source>HELP</source>
+			</trans-unit>
+			<trans-unit id="htmlparser_plugin_title" resname="htmlparser_plugin_title">
+				<source>Examples: HTML parsing</source>
+			</trans-unit>
+			<trans-unit id="make_choice" resname="make_choice">
+				<source>- make a choice!</source>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
+				<source>Core code examples to demonstrate various features</source>
+			</trans-unit>
+			<trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
+				<source>Examples</source>
+			</trans-unit>
+			<trans-unit id="mlang_tabs_tab" resname="mlang_tabs_tab">
+				<source>Examples</source>
+			</trans-unit>
+			<trans-unit id="new_relation" resname="new_relation">
+				<source>Content element &#34;%1$s&#34; (uid: %2$d) has the following relations:</source>
+			</trans-unit>
+			<trans-unit id="new_relation_confirmation" resname="new_relation_confirmation">
 				<source>Confirmation</source>
 			</trans-unit>
-			<trans-unit id="new_relation" xml:space="preserve">
-				<source>Content element "%1$s" (uid: %2$d) has the following relations:</source>
+			<trans-unit id="permissions_header" resname="permissions_header">
+				<source>Custom permissions</source>
+			</trans-unit>
+			<trans-unit id="permissions_option1" resname="permissions_option1">
+				<source>Custom permission #1</source>
+			</trans-unit>
+			<trans-unit id="permissions_option1_description" resname="permissions_option1_description">
+				<source>This allows the user to save things.</source>
+			</trans-unit>
+			<trans-unit id="permissions_option2" resname="permissions_option2">
+				<source>Custom permission #2</source>
+			</trans-unit>
+			<trans-unit id="permissions_option3" resname="permissions_option3">
+				<source>Custom permission #3</source>
+			</trans-unit>
+			<trans-unit id="pierror_wizard_description" resname="pierror_wizard_description">
+				<source>Displays error in the frontend to demonstrate error reporting in TYPO3.</source>
+			</trans-unit>
+			<trans-unit id="pierror_wizard_title" resname="pierror_wizard_title">
+				<source>Error display</source>
+			</trans-unit>
+			<trans-unit id="record_count_message" resname="record_count_message">
+				<source>%s record(s) in table &#34;%s&#34;.</source>
+			</trans-unit>
+			<trans-unit id="record_count_title" resname="record_count_title">
+				<source>Record count</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang_browse_links.xlf
+++ b/Resources/Private/Language/locallang_browse_links.xlf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.0" xmlns:t3="http://typo3.org/schemas/xliff">
-	<file t3:id="1415814849" source-language="en" datatype="plaintext" original="EXT:recordlist/Resources/Private/Language/locallang_browse_links.xlf" date="2011-10-17T20:22:33Z" product-name="lang">
-		<header/>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" original="EXT:recordlist/Resources/Private/Language/locallang_browse_links.xlf" datatype="plaintext" product-name="lang" date="2022-10-20T18:41:26+02:00">
+		<header></header>
 		<body>
-			<trans-unit id="haiku" resname="haiku">
-				<source>Haiku Link</source>
-			</trans-unit>
-			<trans-unit id="github" resname="github">
-				<source>GitHub Issue</source>
+			<trans-unit id="gitHubDescription" resname="gitHubDescription">
+				<source>Enter the &#34;%s&#34; number for the GitHub repository &#34;%s&#34;.</source>
 			</trans-unit>
 			<trans-unit id="gitHubIssueNumber" resname="gitHubIssueNumber">
 				<source>GitHub issue number</source>
 			</trans-unit>
-			<trans-unit id="gitHubDescription" resname="gitHubDescription">
-				<source>Enter the "%s" number for the GitHub repository "%s".</source>
+			<trans-unit id="github" resname="github">
+				<source>GitHub Issue</source>
+			</trans-unit>
+			<trans-unit id="haiku" resname="haiku">
+				<source>Haiku Link</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,208 +1,208 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-	<file source-language="en" datatype="plaintext" original="messages" date="2013-03-09T18:43:47Z" product-name="examples">
-		<header/>
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" original="messages" datatype="plaintext" product-name="examples" date="2022-10-20T18:41:45+02:00">
+		<header></header>
 		<body>
-			<trans-unit id="fe_users.tx_examples_options.I.0" xml:space="preserve">
-				<source>Option 1</source>
-			</trans-unit>
-			<trans-unit id="fe_users.tx_examples_options.I.1" xml:space="preserve">
-				<source>Option 2</source>
-			</trans-unit>
-			<trans-unit id="fe_users.tx_examples_options.I.2" xml:space="preserve">
-				<source>__Final options:__</source>
-			</trans-unit>
-			<trans-unit id="fe_users.tx_examples_options.I.3" xml:space="preserve">
-				<source>Option 3</source>
-			</trans-unit>
-			<trans-unit id="fe_users.tx_examples_options" xml:space="preserve">
-				<source>Test</source>
-			</trans-unit>
-			<trans-unit id="fe_users.tx_examples_special" xml:space="preserve">
-				<source>Special field</source>
-			</trans-unit>
-			<trans-unit id="be_users.tx_examples_mobile" xml:space="preserve">
+			<trans-unit id="be_users.tx_examples_mobile" resname="be_users.tx_examples_mobile">
 				<source>Mobile number</source>
 			</trans-unit>
-			<trans-unit id="tt_content.tx_examples_noprint" xml:space="preserve">
-				<source>No print</source>
-			</trans-unit>
-			<trans-unit id="tt_content.list_type_pi1" xml:space="preserve">
-				<source>Examples: simple FlexForm</source>
-			</trans-unit>
-			<trans-unit id="tt_content.list_type_pi2" xml:space="preserve">
-				<source>Examples: advanced FlexForm</source>
-			</trans-unit>
-			<trans-unit id="tt_content.list_type_pi3" xml:space="preserve">
-				<source>Examples: advanced FlexForm with localization type 1</source>
-			</trans-unit>
-			<trans-unit id="tt_content.list_type_pi4" xml:space="preserve">
-				<source>Examples: advanced FlexForm with localization type 2</source>
-			</trans-unit>
-			<trans-unit id="tt_content.list_type_pierror" xml:space="preserve">
-				<source>Examples: error handling</source>
-			</trans-unit>
-			<trans-unit id="pages.tx_examples_related_pages" xml:space="preserve">
-				<source>Related pages</source>
-			</trans-unit>
-			<trans-unit id="examples.pi_flexform.sheetGeneral" xml:space="preserve">
-				<source>General Setup</source>
-			</trans-unit>
-			<trans-unit id="examples.pi_flexform.pageSelector" xml:space="preserve">
-				<source>Reference page</source>
-			</trans-unit>
-			<trans-unit id="examples.pi_flexform.choosePage" xml:space="preserve">
+			<trans-unit id="examples.pi_flexform.choosePage" resname="examples.pi_flexform.choosePage">
 				<source>Choose a page</source>
 			</trans-unit>
-			<trans-unit id="examples.pi_flexform.s_Message" xml:space="preserve">
-				<source>Message</source>
-			</trans-unit>
-			<trans-unit id="examples.pi_flexform.header" xml:space="preserve">
+			<trans-unit id="examples.pi_flexform.header" resname="examples.pi_flexform.header">
 				<source>Header</source>
 			</trans-unit>
-			<trans-unit id="examples.pi_flexform.message" xml:space="preserve">
+			<trans-unit id="examples.pi_flexform.message" resname="examples.pi_flexform.message">
 				<source>Message</source>
 			</trans-unit>
-			<trans-unit id="tx_examples_dummy" xml:space="preserve">
-				<source>Dummy Table</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_dummy.title" xml:space="preserve">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_dummy.record_type" xml:space="preserve">
-				<source>Type</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_dummy.record_type.0" xml:space="preserve">
-				<source>Normal</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_dummy.record_type.1" xml:space="preserve">
-				<source>Short</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_dummy.record_type.2" xml:space="preserve">
-				<source>Weird</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_dummy.some_date" xml:space="preserve">
-				<source>Some date</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_dummy.enforce_date" xml:space="preserve">
-				<source>Enforce date</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_dummy.description" xml:space="preserve">
-				<source>Description</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku" xml:space="preserve">
-				<source>Haiku</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.hidden.description" xml:space="preserve">
-				<source>Use this field to hide a haiku that should not be published.</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.title" xml:space="preserve">
-				<source>Title</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.title.description" xml:space="preserve">
-				<source>Title of the haiku. Haikus are short Japanese poems that follow a very strict structure.</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.poem" xml:space="preserve">
-				<source>Text</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.poem.description" xml:space="preserve">
-				<source>Enter the text of your haiku in this field. The structure of the haiku is very strict. It is composed of three &quot;lines&quot;. Those &quot;lines&quot; must be made of a very precise number of &quot;syllables&quot;: 5 for the first line / 7 for the second line / 5 for the third line.</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.filesource" xml:space="preserve">
-				<source>Load content from file</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.filestatus" xml:space="preserve">
-				<source>File status</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.season" xml:space="preserve">
-				<source>Season</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.season.description" xml:space="preserve">
-				<source>Choose a season from the list or create a new season.</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.season.spring" xml:space="preserve">
-				<source>Spring</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.season.summer" xml:space="preserve">
-				<source>Summer</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.season.autumn" xml:space="preserve">
-				<source>Autumn</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.season.winter" xml:space="preserve">
-				<source>Winter</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.weirdness" xml:space="preserve">
-				<source>Weirdness</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.weirdness.description" xml:space="preserve">
-				<source>This is a measure of weirdness. Use the wizard to increase or decrease it.</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.color" xml:space="preserve">
-				<source>Color</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.color.description" xml:space="preserve">
-				<source>Choose a color that expresses the mood of your haiku.</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.colorPick" xml:space="preserve">
-				<source>Pick a color</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.angle" xml:space="preserve">
-				<source>Angle</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.images" xml:space="preserve">
-				<source>Images</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.image1" xml:space="preserve">
-				<source>Images (all controls available)</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.image2" xml:space="preserve">
-				<source>Images (no file browser)</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.image3" xml:space="preserve">
-				<source>Images (no upload button)</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.image4" xml:space="preserve">
-				<source>Images (no list display)</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.image5" xml:space="preserve">
-				<source>Images (no delete button)</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.image6" xml:space="preserve">
-				<source>Images (no controls at all)</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.images_fal" xml:space="preserve">
-				<source>Images (FAL)</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.image_fal_group" xml:space="preserve">
-				<source>Images (group-type)</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.image_fal_irre" xml:space="preserve">
-				<source>Images (inline-type)</source>
-			</trans-unit>
-			<trans-unit id="tx_examples_haiku.reference_page" xml:space="preserve">
+			<trans-unit id="examples.pi_flexform.pageSelector" resname="examples.pi_flexform.pageSelector">
 				<source>Reference page</source>
 			</trans-unit>
-			<trans-unit id="tx_examples_haiku.related_records" xml:space="preserve">
-				<source>Related records</source>
+			<trans-unit id="examples.pi_flexform.s_Message" resname="examples.pi_flexform.s_Message">
+				<source>Message</source>
 			</trans-unit>
-			<trans-unit id="tx_examples_haiku.related_content" xml:space="preserve">
-				<source>Related content</source>
+			<trans-unit id="examples.pi_flexform.sheetGeneral" resname="examples.pi_flexform.sheetGeneral">
+				<source>General Setup</source>
 			</trans-unit>
-			<trans-unit id="tx_examples_haiku.related_content.image" xml:space="preserve">
-				<source>Contains "image"</source>
+			<trans-unit id="fe_users.tx_examples_options" resname="fe_users.tx_examples_options">
+				<source>Test</source>
 			</trans-unit>
-			<trans-unit id="tx_examples_haiku.related_content.typo3" xml:space="preserve">
-				<source>Contains "typo3"</source>
+			<trans-unit id="fe_users.tx_examples_options.I.0" resname="fe_users.tx_examples_options.I.0">
+				<source>Option 1</source>
 			</trans-unit>
-			<trans-unit id="tx_examples_haiku.relations" xml:space="preserve">
-				<source>Relations</source>
+			<trans-unit id="fe_users.tx_examples_options.I.1" resname="fe_users.tx_examples_options.I.1">
+				<source>Option 2</source>
 			</trans-unit>
-			<trans-unit id="tt_content.tx_examples_separator" xml:space="preserve">
+			<trans-unit id="fe_users.tx_examples_options.I.2" resname="fe_users.tx_examples_options.I.2">
+				<source>__Final options:__</source>
+			</trans-unit>
+			<trans-unit id="fe_users.tx_examples_options.I.3" resname="fe_users.tx_examples_options.I.3">
+				<source>Option 3</source>
+			</trans-unit>
+			<trans-unit id="fe_users.tx_examples_special" resname="fe_users.tx_examples_special">
+				<source>Special field</source>
+			</trans-unit>
+			<trans-unit id="pages.tx_examples_related_pages" resname="pages.tx_examples_related_pages">
+				<source>Related pages</source>
+			</trans-unit>
+			<trans-unit id="tt_content.list_type_pi1" resname="tt_content.list_type_pi1">
+				<source>Examples: simple FlexForm</source>
+			</trans-unit>
+			<trans-unit id="tt_content.list_type_pi2" resname="tt_content.list_type_pi2">
+				<source>Examples: advanced FlexForm</source>
+			</trans-unit>
+			<trans-unit id="tt_content.list_type_pi3" resname="tt_content.list_type_pi3">
+				<source>Examples: advanced FlexForm with localization type 1</source>
+			</trans-unit>
+			<trans-unit id="tt_content.list_type_pi4" resname="tt_content.list_type_pi4">
+				<source>Examples: advanced FlexForm with localization type 2</source>
+			</trans-unit>
+			<trans-unit id="tt_content.list_type_pierror" resname="tt_content.list_type_pierror">
+				<source>Examples: error handling</source>
+			</trans-unit>
+			<trans-unit id="tt_content.tx_examples_main_category" resname="tt_content.tx_examples_main_category">
+				<source>Main category</source>
+			</trans-unit>
+			<trans-unit id="tt_content.tx_examples_noprint" resname="tt_content.tx_examples_noprint">
+				<source>No print</source>
+			</trans-unit>
+			<trans-unit id="tt_content.tx_examples_separator" resname="tt_content.tx_examples_separator">
 				<source>CSV separator</source>
 			</trans-unit>
-			<trans-unit id="tt_content.tx_examples_main_category" xml:space="preserve">
-				<source>Main category</source>
+			<trans-unit id="tx_examples_dummy" resname="tx_examples_dummy">
+				<source>Dummy Table</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_dummy.description" resname="tx_examples_dummy.description">
+				<source>Description</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_dummy.enforce_date" resname="tx_examples_dummy.enforce_date">
+				<source>Enforce date</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_dummy.record_type" resname="tx_examples_dummy.record_type">
+				<source>Type</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_dummy.record_type.0" resname="tx_examples_dummy.record_type.0">
+				<source>Normal</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_dummy.record_type.1" resname="tx_examples_dummy.record_type.1">
+				<source>Short</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_dummy.record_type.2" resname="tx_examples_dummy.record_type.2">
+				<source>Weird</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_dummy.some_date" resname="tx_examples_dummy.some_date">
+				<source>Some date</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_dummy.title" resname="tx_examples_dummy.title">
+				<source>Title</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku" resname="tx_examples_haiku">
+				<source>Haiku</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.angle" resname="tx_examples_haiku.angle">
+				<source>Angle</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.color" resname="tx_examples_haiku.color">
+				<source>Color</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.color.description" resname="tx_examples_haiku.color.description">
+				<source>Choose a color that expresses the mood of your haiku.</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.colorPick" resname="tx_examples_haiku.colorPick">
+				<source>Pick a color</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.filesource" resname="tx_examples_haiku.filesource">
+				<source>Load content from file</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.filestatus" resname="tx_examples_haiku.filestatus">
+				<source>File status</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.hidden.description" resname="tx_examples_haiku.hidden.description">
+				<source>Use this field to hide a haiku that should not be published.</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.image1" resname="tx_examples_haiku.image1">
+				<source>Images (all controls available)</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.image2" resname="tx_examples_haiku.image2">
+				<source>Images (no file browser)</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.image3" resname="tx_examples_haiku.image3">
+				<source>Images (no upload button)</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.image4" resname="tx_examples_haiku.image4">
+				<source>Images (no list display)</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.image5" resname="tx_examples_haiku.image5">
+				<source>Images (no delete button)</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.image6" resname="tx_examples_haiku.image6">
+				<source>Images (no controls at all)</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.image_fal_group" resname="tx_examples_haiku.image_fal_group">
+				<source>Images (group-type)</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.image_fal_irre" resname="tx_examples_haiku.image_fal_irre">
+				<source>Images (inline-type)</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.images" resname="tx_examples_haiku.images">
+				<source>Images</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.images_fal" resname="tx_examples_haiku.images_fal">
+				<source>Images (FAL)</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.poem" resname="tx_examples_haiku.poem">
+				<source>Text</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.poem.description" resname="tx_examples_haiku.poem.description">
+				<source>Enter the text of your haiku in this field. The structure of the haiku is very strict. It is composed of three &#34;lines&#34;. Those &#34;lines&#34; must be made of a very precise number of &#34;syllables&#34;: 5 for the first line / 7 for the second line / 5 for the third line.</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.reference_page" resname="tx_examples_haiku.reference_page">
+				<source>Reference page</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.related_content" resname="tx_examples_haiku.related_content">
+				<source>Related content</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.related_content.image" resname="tx_examples_haiku.related_content.image">
+				<source>Contains &#34;image&#34;</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.related_content.typo3" resname="tx_examples_haiku.related_content.typo3">
+				<source>Contains &#34;typo3&#34;</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.related_records" resname="tx_examples_haiku.related_records">
+				<source>Related records</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.relations" resname="tx_examples_haiku.relations">
+				<source>Relations</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.season" resname="tx_examples_haiku.season">
+				<source>Season</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.season.autumn" resname="tx_examples_haiku.season.autumn">
+				<source>Autumn</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.season.description" resname="tx_examples_haiku.season.description">
+				<source>Choose a season from the list or create a new season.</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.season.spring" resname="tx_examples_haiku.season.spring">
+				<source>Spring</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.season.summer" resname="tx_examples_haiku.season.summer">
+				<source>Summer</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.season.winter" resname="tx_examples_haiku.season.winter">
+				<source>Winter</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.title" resname="tx_examples_haiku.title">
+				<source>Title</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.title.description" resname="tx_examples_haiku.title.description">
+				<source>Title of the haiku. Haikus are short Japanese poems that follow a very strict structure.</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.weirdness" resname="tx_examples_haiku.weirdness">
+				<source>Weirdness</source>
+			</trans-unit>
+			<trans-unit id="tx_examples_haiku.weirdness.description" resname="tx_examples_haiku.weirdness.description">
+				<source>This is a measure of weirdness. Use the wizard to increase or decrease it.</source>
 			</trans-unit>
 		</body>
 	</file>


### PR DESCRIPTION
This was done with [t3ll](https://github.com/garfieldius/t3ll). Additionally, the keys are sorted alphabetically.

XLIFF version 1.2 can be validated against a schema. Next step would then be to lint the XLIFF files in a CI run.