### PR TITLE
[TASK] Streamline Haiku DetailController

### DIFF
--- a/Classes/Controller/Haiku/DetailController.php
+++ b/Classes/Controller/Haiku/DetailController.php
@@ -61,7 +61,7 @@ class DetailController
         $parameter = $request->getQueryParams()['tx_examples_haiku']??[];
         $action = $parameter['action'] ?? '';
         try {
-            $result = match ($action) {
+            return match ($action) {
                 'show' => $this->showAction((int)($parameter['haiku'] ?? 0)),
                 'findByTitle' => $this->findByTitleAction((string)($parameter['haiku_title'] ?? '')),
                 default => $this->notFoundAction('Action ' . $action . ' not found.'),
@@ -69,13 +69,12 @@ class DetailController
         } catch (\Exception $e) {
             $this->notFoundAction($e->getMessage());
         }
-        return $result;
     }
 
     /**
      * @throws PropagateResponseException
      */
-    private function notFoundAction(string $reason)
+    private function notFoundAction(string $reason): never
     {
         throw new PropagateResponseException(
             new Response(

--- a/Classes/Controller/Haiku/DetailController.php
+++ b/Classes/Controller/Haiku/DetailController.php
@@ -24,14 +24,14 @@ use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
-class DetailController
+final class DetailController
 {
     /**
      * The back-reference to the mother cObj object set at call time
      */
-    public ContentObjectRenderer $cObj;
-    public array $conf = [];
-    public StandaloneView $view;
+    private ContentObjectRenderer $cObj;
+    private array $conf = [];
+    private StandaloneView $view;
 
     public function __construct(
         private readonly HaikuRepository $haikuRepository,


### PR DESCRIPTION
With PHP 8.1 a new return type "never" was introduced. This type declares that the method would - well - never return anything. So we add it to notFoundAction(). Then we can streamline the main() method to return immediately instead of assigning the result to a variable and return later.

This is a preparation for applying more Rector rules.

Additionally, set class to final as opinionated best practise and properties to private as they are not needed outside (which would be bad practise anyway).