### PR TITLE
[TASK] Apply UP_TO_PHP_74 level set list to Rector rules

### DIFF
--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -49,7 +49,7 @@ class AdminModuleController
             $GLOBALS['BE_USER']->pushModuleData($moduleData->getModuleIdentifier(), $moduleData->toArray());
         }
 
-        $moduleTemplate = $this->moduleTemplateFactory->create($request, 't3docs/examples');
+        $moduleTemplate = $this->moduleTemplateFactory->create($request);
         $this->setUpDocHeader($request, $moduleTemplate);
 
         $title = $GLOBALS['LANG']->sL('LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf:mlang_tabs_tab');

--- a/Classes/LinkHandler/GithubLinkBuilder.php
+++ b/Classes/LinkHandler/GithubLinkBuilder.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Frontend\Typolink\UnableToLinkException;
  */
 class GithubLinkBuilder extends AbstractTypolinkBuilder
 {
-    const TYPE_GITHUB = 'github';
+    private const TYPE_GITHUB = 'github';
 
     public function build(
         array &$linkDetails,

--- a/rector.php
+++ b/rector.php
@@ -16,20 +16,23 @@ declare(strict_types=1);
  */
 
 use Rector\Config\RectorConfig;
-use Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
+use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
+use Rector\Set\ValueObject\LevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
         __DIR__ . '/.',
     ]);
 
-    // register a single rule
-    $rectorConfig->rule(TernaryToNullCoalescingRector::class);
-
-    /*
-        Apply all rules for a certain PHP version
-        $rectorConfig->sets([
-                LevelSetList::UP_TO_PHP_74
-        ]);
-    */
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_74
+    ]);
+    
+    $rectorConfig->skip([
+        AddLiteralSeparatorToNumberRector::class,
+        JsonThrowOnErrorRector::class => [
+            __DIR__ . '/Classes/Http/MeowInformationRequester.php',
+        ]
+    ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -26,13 +26,13 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_74
+        LevelSetList::UP_TO_PHP_74,
     ]);
-    
+
     $rectorConfig->skip([
         AddLiteralSeparatorToNumberRector::class,
         JsonThrowOnErrorRector::class => [
             __DIR__ . '/Classes/Http/MeowInformationRequester.php',
-        ]
+        ],
     ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 
 use Rector\Config\RectorConfig;
-use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
 use Rector\Set\ValueObject\LevelSetList;
 


### PR DESCRIPTION
This is the first part of applying the UP_TO_PHP_xx level set lists until PHP 8.1. This way the changes are small.

The TernaryToNullCoalescingRector is part of the PHP 7.0 rule set and can therefore be omitted.

The GithubLinkBuilder::TYPE_GITHUB constant was set to private manually as the Rector rule would set it to public (which is not needed in this case).

The moduleTemplateFactory->create() method only accepts one argument, therefore Rector removed the second one.

The AddLiteralSeparatorToNumberRector is skipped as this would format exception codes (timestamps) like 1_234_567_890 (which is not needed for readability here).