### PR TITLE
[BUGFIX] Use flag JSON_THROW_ON_ERROR

### DIFF
--- a/Classes/Command/MeowInformationCommand.php
+++ b/Classes/Command/MeowInformationCommand.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace T3docs\Examples\Command;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,6 +28,7 @@ final class MeowInformationCommand extends Command
 {
     public function __construct(
         private readonly MeowInformationRequester $requester,
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
     }
@@ -36,16 +38,21 @@ final class MeowInformationCommand extends Command
         $this->setHelp('Prints random information about cats retrieved from an API call');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output
+    ): int {
         $io = new SymfonyStyle($input, $output);
         $io->title($this->getDescription());
 
         try {
             $detail = $this->requester->request();
+        } catch (\JsonException $e) {
+            $this->logger->error($e->getMessage());
+            $io->error('The service did not return a valid response. Try again later.');
+            return Command::FAILURE;
         } catch (\Exception $e) {
             $io->error($e->getMessage());
-
             return Command::FAILURE;
         }
 

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -32,6 +32,7 @@ final class MeowInformationRequester
 
     /**
      * @throws \JsonException
+     * @throws \RuntimeException
      */
     public function request(): string
     {

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -59,7 +59,6 @@ final class MeowInformationRequester
         }
 
         // Get the content as a string on a successful request
-        return json_decode($response->getBody()->getContents(), true)['fact']
-            ?? throw new \RuntimeException('No information available');
+        return json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR)['fact'];
     }
 }

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -63,7 +63,7 @@ final class MeowInformationRequester
         }
         // Get the content as a string on a successful request
         $content = $response->getBody()->getContents();
-        return (string) json_decode($content, true, flags: JSON_THROW_ON_ERROR)['fact']??
+        return (string)json_decode($content, true, flags: JSON_THROW_ON_ERROR)['fact']??
             throw new \RuntimeException('The service returned an unexpected format.', 1666413230);
     }
 }

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 
 namespace T3docs\Examples\Http;
 
-use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Http\RequestFactory;
 
 final class MeowInformationRequester

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -62,8 +62,7 @@ final class MeowInformationRequester
         }
         // Get the content as a string on a successful request
         $content = $response->getBody()->getContents();
-        $result = json_decode($content, true, flags: JSON_THROW_ON_ERROR)['fact'];
-        return is_string($result) ? $result
-            : throw new \RuntimeException('The service returned an unexpected format: ' . gettype($result), 1666413230);
+        return (string) json_decode($content, true, flags: JSON_THROW_ON_ERROR)['fact']??
+            throw new \RuntimeException('The service returned an unexpected format. ', 1666413230);
     }
 }

--- a/Classes/Http/MeowInformationRequester.php
+++ b/Classes/Http/MeowInformationRequester.php
@@ -63,6 +63,6 @@ final class MeowInformationRequester
         // Get the content as a string on a successful request
         $content = $response->getBody()->getContents();
         return (string) json_decode($content, true, flags: JSON_THROW_ON_ERROR)['fact']??
-            throw new \RuntimeException('The service returned an unexpected format. ', 1666413230);
+            throw new \RuntimeException('The service returned an unexpected format.', 1666413230);
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -25,6 +26,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // register a single rule
     $rectorConfig->rule(TernaryToNullCoalescingRector::class);
+    $rectorConfig->rule(JsonThrowOnErrorRector::class);
 
     /*
         Apply all rules for a certain PHP version


### PR DESCRIPTION
We do not need to throw an exception ourselves then as json_decode will throw an error now when parsing the json failed