### PR TITLE
[BUGFIX] Avoid undefined array key in clipboard module

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -219,7 +219,7 @@ class ModuleController extends ActionController implements LoggerAwareInterface
     public function clipboardAction(
         string $cmd = 'show'
     ): ResponseInterface {
-        $cmd = $_POST['tx_examples_tools_examplesexamples']['cmd'];
+        $cmd = $_POST['tx_examples_tools_examplesexamples']['cmd'] ?? '';
         switch ($cmd) {
             case 'debug':
                 $this->debugClipboard();


### PR DESCRIPTION
This happens when selecting the "Clipboard" third-level module:

PHP Warning: Undefined array key "tx_examples_tools_examplesexamples" in Classes/Controller/ModuleController.php line 222