### PR TITLE
[TASK] Unify web-dir in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         },
         "typo3/cms": {
             "extension-key": "examples",
-            "web-dir": ".Build/web"
+            "web-dir": ".Build/Web"
         }
     },
     "scripts": {


### PR DESCRIPTION
In order to unify some paths across extension, it is recommended to use web-dir ".Build/Web".

For examples, this does not have any impact, as the web-dir is currently not used.

But, in general, the paths are sometimes used in scripts (runTests.sh) or configuration files (e.g. phpstan.neon), so it helps to unify things if the common defaults are used.

This concerns:

- web-dir: .Build/Web
- bin-dir: .Build/bin
- vendor-dir: .Build/vendor

Related: TYPO3-Documentation/tea#802