### PR TITLE
[TASK] Avoid using deprecated LanguageService->includeLLFile() method

### DIFF
--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -36,13 +36,17 @@ final class AdminModuleController
 
     public function handleRequest(ServerRequestInterface $request): ResponseInterface
     {
-        $GLOBALS['LANG']->includeLLFile('EXT:examples/Resources/Private/Language/AdminModule/locallang.xlf');
-
         $allowedOptions = [
             'function' => [
-                'debug' => $GLOBALS['LANG']->getLL('debug'),
-                'password' => $GLOBALS['LANG']->getLL('password'),
-                'index' => $GLOBALS['LANG']->getLL('index'),
+                'debug' => htmlspecialchars(
+                    $GLOBALS['LANG']->sL('EXT:examples/Resources/Private/Language/AdminModule/locallang.xlf:debug')
+                ),
+                'password' => htmlspecialchars(
+                    $GLOBALS['LANG']->sL('EXT:examples/Resources/Private/Language/AdminModule/locallang.xlf:password')
+                ),
+                'index' => htmlspecialchars(
+                    $GLOBALS['LANG']->sL('EXT:examples/Resources/Private/Language/AdminModule/locallang.xlf:index')
+                ),
             ],
         ];
 


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/472
Releases: main