### PR TITLE
[TASK] Use associative array keys for TCA items

### DIFF
--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -26,11 +26,26 @@ $temporaryColumns = [
             'type' => 'select',
             'renderType' => 'selectSingle',
             'items' => [
-                ['', 0],
-                ['LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.0', 1],
-                ['LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.1', 2],
-                ['LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.2', '--div--'],
-                ['LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.3', 3],
+                [
+                    'label' => '',
+                    'value' => 0,
+                ],
+                [
+                    'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.0',
+                    'value' => 1,
+                ],
+                [
+                    'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.1',
+                    'value' => 2,
+                ],
+                [
+                    'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.2',
+                    'value' => '--div--',
+                ],
+                [
+                    'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.3',
+                    'value' => 3,
+                ],
             ],
             'size' => 1,
             'maxitems' => 1,

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -29,8 +29,14 @@ $temporaryColumn = [
             'foreign_table_where' => 'ORDER BY pages.sorting',
             'size' => 20,
             'items' => [
-                ['static from tca 4711', 4711],
-                ['static from tca 4712', 4712],
+                [
+                    'label' => 'static from tca 4711',
+                    'value' => 4711,
+                ],
+                [
+                    'label' => 'static from tca 4712',
+                    'value' => 4712,
+                ],
             ],
             'treeConfig' => [
                 'parentField' => 'pid',

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -28,8 +28,8 @@ $temporaryColumn = [
             'renderType' => 'checkboxToggle',
             'items' => [
                 [
-                    0 => '',
-                    1 => '',
+                    'label' => '',
+                    'value' => '',
                 ],
             ],
         ],
@@ -41,12 +41,30 @@ $temporaryColumn = [
             'type' => 'select',
             'renderType' => 'selectSingle',
             'items' => [
-                ['Standard CSV data formats', '--div--'],
-                ['Comma separated', ','],
-                ['Semicolon separated', ';'],
-                ['Special formats', '--div--'],
-                ['Pipe separated (TYPO3 tables)', '|'],
-                ['Tab separated', "\t"],
+                [
+                    'label' => 'Standard CSV data formats',
+                    'value' => '--div--',
+                ],
+                [
+                    'label' => 'Comma separated',
+                    'value' => ',',
+                ],
+                [
+                    'label' => 'Semicolon separated',
+                    'value' => ';',
+                ],
+                [
+                    'label' => 'Special formats',
+                    'value' => '--div--',
+                ],
+                [
+                    'label' => 'Pipe separated (TYPO3 tables)',
+                    'value' => '|',
+                ],
+                [
+                    'label' => 'Tab separated',
+                    'value' => "\t",
+                ],
             ],
             'default' => ',',
         ],
@@ -58,7 +76,10 @@ $temporaryColumn = [
             'type' => 'select',
             'renderType' => 'selectSingle',
             'items' => [
-                ['None', '0'],
+                [
+                    'label' => 'None',
+                    'value' => '0',
+                ],
             ],
             'foreign_table' => 'sys_category',
             'foreign_table_where' => 'AND {#sys_category}.{#pid} = ###PAGE_TSCONFIG_ID### AND {#sys_category}.{#hidden} = 0 ' .
@@ -165,9 +186,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_newcontentcsv_title',
-        'examples_newcontentcsv',
-        'mimetypes-x-content-table',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_newcontentcsv_title',
+        'value' => 'examples_newcontentcsv',
+        'icon' => 'mimetypes-x-content-table',
     ],
 );
 
@@ -194,9 +215,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_newcontentelement_title',
-        'examples_newcontentelement',
-        'content-text',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_newcontentelement_title',
+        'value' => 'examples_newcontentelement',
+        'icon' => 'content-text',
     ],
     'textmedia',
     'after'
@@ -227,9 +248,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocdb_title',
-        'examples_dataprocdb',
-        'mimetypes-x-content-table',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocdb_title',
+        'value' => 'examples_dataprocdb',
+        'icon' => 'mimetypes-x-content-table',
     ],
 );
 
@@ -247,9 +268,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocmenu_title',
-        'examples_dataprocmenu',
-        'content-special-uploads',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocmenu_title',
+        'value' => 'examples_dataprocmenu',
+        'icon' => 'content-special-uploads',
     ],
 );
 
@@ -266,9 +287,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataproclang_title',
-        'examples_dataproclang',
-        'install-manage-language',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataproclang_title',
+        'value' => 'examples_dataproclang',
+        'icon' => 'install-manage-language',
     ],
 );
 
@@ -284,9 +305,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocsite_title',
-        'examples_dataprocsite',
-        'apps-pagetree-folder-root',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocsite_title',
+        'value' => 'examples_dataprocsite',
+        'icon' => 'apps-pagetree-folder-root',
     ],
 );
 
@@ -303,9 +324,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocsitelanguage_title',
-        'examples_dataprocsitelanguage',
-        'content-message',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocsitelanguage_title',
+        'value' => 'examples_dataprocsitelanguage',
+        'icon' => 'content-message',
     ],
 );
 
@@ -322,9 +343,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocsplit_title',
-        'examples_dataprocsplit',
-        'content-timeline',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocsplit_title',
+        'value' => 'examples_dataprocsplit',
+        'icon' => 'content-timeline',
     ],
 );
 
@@ -340,9 +361,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocfiles_title',
-        'examples_dataprocfiles',
-        'content-image',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocfiles_title',
+        'value' => 'examples_dataprocfiles',
+        'icon' => 'content-image',
     ],
 );
 
@@ -360,9 +381,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocgallery_title',
-        'examples_dataprocgallery',
-        'content-dashboard',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataprocgallery_title',
+        'value' => 'examples_dataprocgallery',
+        'icon' => 'content-dashboard',
     ],
 );
 
@@ -381,9 +402,9 @@ ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
     'CType',
     [
-        'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataproccustom_title',
-        'examples_dataproccustom',
-        'content-dashboard',
+        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:examples_dataproccustom_title',
+        'value' => 'examples_dataproccustom',
+        'icon' => 'content-dashboard',
     ],
 );
 


### PR DESCRIPTION
This avoids deprecation notices and TCA migrations.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/401