### PR TITLE
[FEATURE] Add example for a custom reaction type

### DIFF
--- a/Classes/Reaction/ExampleReactionType.php
+++ b/Classes/Reaction/ExampleReactionType.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace T3docs\Examples\Reaction;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use TYPO3\CMS\Core\Registry;
+use TYPO3\CMS\Reactions\Model\ReactionInstruction;
+use TYPO3\CMS\Reactions\Reaction\ReactionInterface;
+
+class ExampleReactionType implements ReactionInterface
+{
+    private const REGISTRY_KEY = 'changed_ids';
+
+    public function __construct(
+        private readonly Registry $registry,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public static function getType(): string
+    {
+        return 'example-reaction-type';
+    }
+
+    public static function getDescription(): string
+    {
+        return 'Example reaction type';
+    }
+
+    public static function getIconIdentifier(): string
+    {
+        return 'tx_examples-dummy';
+    }
+
+    /**
+     * @param array{id: int} $payload
+     */
+    public function react(
+        ServerRequestInterface $request,
+        array $payload,
+        ReactionInstruction $reaction
+    ): ResponseInterface {
+        $id = (int)($payload['id'] ?? 0);
+        if ($id <= 0) {
+            $data = [
+                'success' => false,
+                'error' => 'id not given',
+            ];
+
+            return $this->jsonResponse($data, 400);
+        }
+
+        $this->updateRegistryEntry($id);
+
+        return $this->jsonResponse(['success' => true]);
+    }
+
+    private function updateRegistryEntry(int $id): void
+    {
+        $ids = $this->registry->get('tx_examples', self::REGISTRY_KEY) ?? [];
+        $ids[] = $id;
+        $ids = array_unique($ids);
+        $this->registry->set('tx_examples', self::REGISTRY_KEY, $ids);
+    }
+
+    private function jsonResponse(array $data, int $statusCode = 201): ResponseInterface
+    {
+        return $this->responseFactory
+            ->createResponse($statusCode)
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->streamFactory->createStream(json_encode($data, JSON_THROW_ON_ERROR)));
+    }
+}

--- a/Configuration/TCA/Overrides/sys_reaction.php
+++ b/Configuration/TCA/Overrides/sys_reaction.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+defined('TYPO3') or die();
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItem(
+    'sys_reaction',
+    'reaction_type',
+    [
+        'label' => \T3docs\Examples\Reaction\ExampleReactionType::getDescription(),
+        'value' => \T3docs\Examples\Reaction\ExampleReactionType::getType(),
+        'icon' => \T3docs\Examples\Reaction\ExampleReactionType::getIconIdentifier(),
+    ]
+);

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "typo3/cms-extbase": "^12.4 || dev-main",
         "typo3/cms-fluid": "^12.4 || dev-main",
         "typo3/cms-fluid-styled-content": "^12.4 || dev-main",
-        "typo3/cms-linkvalidator": "^12.4 || dev-main"
+        "typo3/cms-linkvalidator": "^12.4 || dev-main",
+		"typo3/cms-reactions": "^12.4 || dev-main"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.31",


### PR DESCRIPTION
The incoming webhook retrieves an id which is stored in the registry.

The full scenario for the EXT:reactions docs:

1. Retrieve an id (which may be changed product id from some third-party system)
2. Store it in the registry.
3. A command (started regularly by a cronjob) can pick it up and synchronize that changed product ids (which may be time-consuming, therefore not done in the incoming request).