### PR TITLE
[BUGFIX] Move ExtensionManagementUtility::addUserTSConfig

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -131,4 +131,9 @@ defined('TYPO3') or die();
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['de']
             ['EXT:frontend/Resources/Private/Language/locallang_tca.xlf'][] =
         'EXT:examples/Resources/Private/Language/de.custom.xlf';
+    
+    // Add default user tsconfig
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig(
+        "@import 'EXT:examples/Configuration/TsConfig/User/*.tsconfig'"
+    );
 })();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -131,7 +131,7 @@ defined('TYPO3') or die();
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['de']
             ['EXT:frontend/Resources/Private/Language/locallang_tca.xlf'][] =
         'EXT:examples/Resources/Private/Language/de.custom.xlf';
-    
+
     // Add default user tsconfig
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig(
         "@import 'EXT:examples/Configuration/TsConfig/User/*.tsconfig'"

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -43,9 +43,4 @@ defined('TYPO3') or die();
             'allowedTables' => '*',
         ]
     );
-
-    // Add custom doktype to the page tree toolbar
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig(
-        "@import 'EXT:examples/Configuration/TsConfig/User/*.tsconfig'"
-    );
 })();


### PR DESCRIPTION
I just had a talk with lolli,`ExtensionManagementUtility::addUserTSConfig` may only be called int the ext_localconf.php, see also the comment for that method.