### PR TITLE
[TASK] Explicitly define PHP version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-		"php": "^8.1",
+        "php": "^8.1",
         "typo3/cms-backend": "dev-main",
         "typo3/cms-core": "dev-main",
         "typo3/cms-extbase": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     ],
     "require": {
+		"php": "^8.1",
         "typo3/cms-backend": "dev-main",
         "typo3/cms-core": "dev-main",
         "typo3/cms-extbase": "dev-main",


### PR DESCRIPTION
This way, PhpStorm picks up this version as language level.

Releases: main, 12.4