### PR TITLE
[Backport 12.4] [TASK] Explicitly define PHP version constraint (#197)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     ],
     "require": {
+        "php": "^8.1",
         "typo3/cms-backend": "^12.4",
         "typo3/cms-core": "^12.4",
         "typo3/cms-extbase": "^12.4",


### PR DESCRIPTION
This way, PhpStorm picks up this version as language level.

Releases: main, 12.4