### PR TITLE
[CI] Update actions/checkout to version 4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Publish new version to TER
         uses: tomasnorre/typo3-upload-ter@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
     name: Linting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php:
@@ -16,20 +16,20 @@ jobs:
           - '8.3'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint PHP
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
   code-quality:
     name: Code Quality
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       php: '8.1'
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install testing system
         run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerUpdate
@@ -48,10 +48,10 @@ jobs:
 
   xliff-lint:
     name: "XLIFF linter"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "XLIFF lint"
         uses: TYPO3-Continuous-Integration/TYPO3-CI-Xliff-Lint@v1


### PR DESCRIPTION
This also avoid the following deprecation on publish: "The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2."

Additionally, use ubuntu-latest instead of a dedicated version to avoid outdated Ubuntu versions which are not supported anymore by GitHub in the future.

Releases: main, 12.4