### PR TITLE
Fix module registration for plain (non-extbase) controller

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -42,7 +42,6 @@ return [
         'workspaces' => 'live',
         'path' => '/module/system/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf',
-        'extensionName' => 'Examples',
         'iconIdentifier' => 'tx_examples-backend-module',
         'routes' => [
            '_default' => [


### PR DESCRIPTION
As there is no need to set the extensionName option according to TYPO3 API Docs.