### PR TITLE
[Backport 12.4] [BUGFIX] Avoid dynamic properties in ModuleController (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Fixed
+- Dynamic properties in ModuleController (#221)
+
 ## 12.0.1 - 2023-09-16
 
 ### Fixed

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -53,6 +53,9 @@ class ModuleController extends ActionController implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
+    private int $pageUid;
+    private array $exampleConfig;
+
     public function __construct(
         protected readonly ModuleTemplateFactory $moduleTemplateFactory,
         protected readonly IconFactory $iconFactory,


### PR DESCRIPTION
Resolves: #221
Releases: main, 12.4