### PR TITLE
[TASK] Use php-cs-fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,9 +1,6 @@
 <?php
 
-$config = \TYPO3\CodingStandards\CsFixerConfig::create();
-$config
-    ->getFinder()->in(__DIR__)
-;
+declare(strict_types=1);
 
 $header = <<<EOF
 This file is part of the TYPO3 CMS project.
@@ -18,8 +15,75 @@ LICENSE.txt file that was distributed with this source code.
 The TYPO3 project - inspiring people to share!
 EOF;
 
-$config->addRules([
-    'header_comment' => ['header' => $header, 'separate' => 'both'],
-]);
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
 
-return $config;
+return (new Config())
+    ->setFinder(
+        (new Finder())
+            ->in(__DIR__)
+    )
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@DoctrineAnnotation' => true,
+        // @todo: Switch to @PER-CS2.0 once php-cs-fixer's todo list is done: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7247
+        '@PER-CS1.0' => true,
+        'array_indentation' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'cast_spaces' => ['space' => 'none'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => ['space' => 'none'],
+        'declare_parentheses' => true,
+        'dir_constant' => true,
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'function_declaration' => [
+            'closure_fn_spacing' => 'none',
+        ],
+        'function_to_constant' => ['functions' => ['get_called_class', 'get_class', 'get_class_this', 'php_sapi_name', 'phpversion', 'pi']],
+        'type_declaration_spaces' => true,
+        'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
+        'list_syntax' => ['syntax' => 'short'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'method_argument_space' => true,
+        'modernize_strpos' => true,
+        'modernize_types_casting' => true,
+        'native_function_casing' => true,
+        'no_alias_functions' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unused_imports' => true,
+        'no_useless_nullsafe_operator' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+        'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
+        'php_unit_mock_short_will_return' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'return_type_declaration' => ['space_before' => 'none'],
+        'single_quote' => true,
+        'single_space_around_construct' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'single_line_empty_body' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+
+        // Additional for this package
+        'header_comment' => ['header' => $header, 'separate' => 'both'],
+    ]);

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -44,9 +44,9 @@ return [
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf',
         'iconIdentifier' => 'tx_examples-backend-module',
         'routes' => [
-           '_default' => [
-               'target' => AdminModuleController::class . '::handleRequest',
-           ],
-       ],
+            '_default' => [
+                'target' => AdminModuleController::class . '::handleRequest',
+            ],
+        ],
     ],
 ];

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "~2.39.0",
-        "rector/rector": "0.17.10",
-        "typo3/coding-standards": "^0.7.1"
+        "friendsofphp/php-cs-fixer": "^3.48",
+        "rector/rector": "0.17.10"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
typo3/coding-standards is not compatible with Symfony 7 (necessary for TYPO3 v13), so we use php-cs-fixer directly instead of relying on another package.

The rules for the php-cs-fixer are the same as for TYPO3 Core.

Releases: main, 12.4