### PR TITLE
[TASK] Add return type to ModuleController->initializeAction()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Use Configuration/user.tsconfig (#214)
+- Add return type to `ModuleController->initializeAction()`
 
 ### Fixed
 - Dynamic properties in ModuleController (#221)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Use Configuration/user.tsconfig (#214)
-- Add return type to `ModuleController->initializeAction()`
+- Add return type to `ModuleController->initializeAction()` (#233)
 
 ### Fixed
 - Dynamic properties in ModuleController (#221)

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -630,7 +630,7 @@ class ModuleController extends ActionController implements LoggerAwareInterface
     /**
      * Function will be called before every other action
      */
-    protected function initializeAction()
+    protected function initializeAction(): void
     {
         $this->pageUid = (int)($this->request->getQueryParams()['id'] ?? 0);
         $this->exampleConfig = $this->extensionConfiguration->get('examples') ?? [];


### PR DESCRIPTION
This is necessary to be compatible with TYPO3 v13.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/810
Releases: main