### PR TITLE
[TASK] Use attribute in commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Use Configuration/user.tsconfig (#214)
 - Add return type to `ModuleController->initializeAction()` (#233)
 - Use PHP attribute for tagging event listener (#236)
+- Use PHP attribute for tagging commands where applicabel
 
 ### Fixed
 - Dynamic properties in ModuleController (#221)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Use Configuration/user.tsconfig (#214)
 - Add return type to `ModuleController->initializeAction()` (#233)
 - Use PHP attribute for tagging event listener (#236)
-- Use PHP attribute for tagging commands where applicabel
+- Use PHP attribute for tagging commands where applicable (#237)
 
 ### Fixed
 - Dynamic properties in ModuleController (#221)

--- a/Classes/Command/DoSomethingCommand.php
+++ b/Classes/Command/DoSomethingCommand.php
@@ -17,11 +17,16 @@ declare(strict_types=1);
 
 namespace T3docs\Examples\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DoSomethingCommand extends Command
+#[AsCommand(
+    name: 'examples:dosomething',
+    description: 'A command that does nothing and always succeeds.',
+)]
+final class DoSomethingCommand extends Command
 {
     protected function configure(): void
     {

--- a/Classes/Command/MeowInformationCommand.php
+++ b/Classes/Command/MeowInformationCommand.php
@@ -18,12 +18,17 @@ declare(strict_types=1);
 namespace T3docs\Examples\Command;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use T3docs\Examples\Http\MeowInformationRequester;
 
+#[AsCommand(
+    name: 'examples:meow',
+    description: 'Meow Information',
+)]
 final class MeowInformationCommand extends Command
 {
     public function __construct(

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -12,12 +12,6 @@ services:
     tags:
       - name: linkvalidator.linktype
 
-  T3docs\Examples\Command\DoSomethingCommand:
-    tags:
-      - name: console.command
-        command: 'examples:dosomething'
-        description: 'A command that does nothing and always succeeds.'
-
   T3docs\Examples\Command\CreateWizardCommand:
     tags:
       - name: console.command
@@ -25,12 +19,6 @@ services:
         description: 'A command that creates a wizard. It is hidden in the command list. You cannot use it in the scheduler.'
         hidden: true
         schedulable: false
-
-  T3docs\Examples\Command\MeowInformationCommand:
-    tags:
-      - name: 'console.command'
-        command: 'examples:meow'
-        description: 'Meow Information'
 
   T3docs\Examples\Controller\Haiku\DetailController:
     public: true


### PR DESCRIPTION
The CreateWizardCommand can't be adjusted to use the attribute as it is set to `schedulable: false` (which is not possible with the Symfony attribute).

Additionally, the DoSomethingCommand is defined as final.

Releases: main