### PR TITLE
[TASK] Restore tagging via Services.yaml for DoSomethingCommand

### DIFF
--- a/Classes/Command/DoSomethingCommand.php
+++ b/Classes/Command/DoSomethingCommand.php
@@ -17,15 +17,10 @@ declare(strict_types=1);
 
 namespace T3docs\Examples\Command;
 
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(
-    name: 'examples:dosomething',
-    description: 'A command that does nothing and always succeeds.',
-)]
 final class DoSomethingCommand extends Command
 {
     protected function configure(): void

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -12,6 +12,12 @@ services:
     tags:
       - name: linkvalidator.linktype
 
+  T3docs\Examples\Command\DoSomethingCommand:
+    tags:
+      - name: console.command
+        command: 'examples:dosomething'
+        description: 'A command that does nothing and always succeeds.'
+
   T3docs\Examples\Command\CreateWizardCommand:
     tags:
       - name: console.command


### PR DESCRIPTION
In TYPO3 Explained we use this snipped in the commands tutorial. We'll describe there the tagging of commands via Services.yaml as the property `schedulable` (which is described there) is not available via the attribute.

Releases: main