### PR TITLE
Removes outdated  langDisable and langChildren

### DIFF
--- a/Configuration/Flexforms/flexform_ds4.xml
+++ b/Configuration/Flexforms/flexform_ds4.xml
@@ -1,7 +1,5 @@
 <T3DataStructure>
     <meta>
-        <langDisable>0</langDisable>
-        <langChildren>1</langChildren>
     </meta>
     <sheets>
         <sDEF>


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/7.6/Deprecation-70138-FlexFormLanguageHandling.html#description