### PR TITLE
[TASK] Remove outdated langDisable and langChildren tags

### DIFF
--- a/Configuration/Flexforms/HtmlParser.xml
+++ b/Configuration/Flexforms/HtmlParser.xml
@@ -1,7 +1,4 @@
 <T3DataStructure>
-    <meta>
-        <langDisable>1</langDisable>
-    </meta>
     <sheets>
         <sDEF>
             <ROOT>

--- a/Configuration/Flexforms/PluginHaikuDetail.xml
+++ b/Configuration/Flexforms/PluginHaikuDetail.xml
@@ -1,7 +1,4 @@
 <T3DataStructure>
-    <meta>
-        <langDisable>1</langDisable>
-    </meta>
     <sheets>
         <sDEF>
             <ROOT>

--- a/Configuration/Flexforms/PluginHaikuList.xml
+++ b/Configuration/Flexforms/PluginHaikuList.xml
@@ -1,7 +1,4 @@
 <T3DataStructure>
-    <meta>
-        <langDisable>1</langDisable>
-    </meta>
     <sheets>
         <sDEF>
             <ROOT>

--- a/Configuration/Flexforms/flexform_ds1.xml
+++ b/Configuration/Flexforms/flexform_ds1.xml
@@ -1,7 +1,4 @@
 <T3DataStructure>
-    <meta>
-        <langDisable>1</langDisable>
-    </meta>
     <sheets>
         <sDEF>
             <ROOT>

--- a/Configuration/Flexforms/flexform_ds2.xml
+++ b/Configuration/Flexforms/flexform_ds2.xml
@@ -1,7 +1,4 @@
 <T3DataStructure>
-    <meta>
-        <langDisable>1</langDisable>
-    </meta>
     <sheets>
         <sDEF>
             <ROOT>

--- a/Configuration/Flexforms/flexform_ds3.xml
+++ b/Configuration/Flexforms/flexform_ds3.xml
@@ -1,7 +1,4 @@
 <T3DataStructure>
-    <meta>
-        <langDisable>0</langDisable>
-    </meta>
     <sheets>
         <sDEF>
             <ROOT>

--- a/Configuration/Flexforms/flexform_ds4.xml
+++ b/Configuration/Flexforms/flexform_ds4.xml
@@ -1,8 +1,4 @@
 <T3DataStructure>
-    <meta>
-        <langDisable>0</langDisable>
-        <langChildren>1</langChildren>
-    </meta>
     <sheets>
         <sDEF>
             <ROOT>


### PR DESCRIPTION
This is deprecated since 7.6
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/7.6/Deprecation-70138-FlexFormLanguageHandling.html#description
Releases: main, 12.4