### PR TITLE
[BUGFIX] Avoid warning when set up extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Use PHP attribute for tagging event listener (#236)
 - Use PHP attribute for tagging commands where applicable (#237)
 
+## 12.0.5 - 2024-04-xx
+
+### Fixed
+- Warning when set up extension (#253)
+
 ## 12.0.4 - 2024-03-29
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "typo3/cms-extbase": "dev-main",
         "typo3/cms-fluid": "dev-main",
         "typo3/cms-fluid-styled-content": "dev-main",
-		"typo3/cms-impexp": "dev-main",
+        "typo3/cms-impexp": "dev-main",
         "typo3/cms-linkvalidator": "dev-main",
         "typo3/cms-reactions": "dev-main"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "typo3/cms-extbase": "dev-main",
         "typo3/cms-fluid": "dev-main",
         "typo3/cms-fluid-styled-content": "dev-main",
+		"typo3/cms-impexp": "dev-main",
         "typo3/cms-linkvalidator": "dev-main",
         "typo3/cms-reactions": "dev-main"
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -27,9 +27,10 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '13.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '13.0.0-13.9.99',
-            'fluid_styled_content' => '13.0.0-13.9.99',
-            'linkvalidator' => '13.0.0-13.9.99',
+            'typo3' => '13.0.0-13.4.99',
+            'impexp' => '13.0.0-13.4.99',
+            'fluid_styled_content' => '13.0.0-13.4.99',
+            'linkvalidator' => '13.0.0-13.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
When running the command

    vendor/bin/typo3 setup:extension -e examples

the following warning was raised:

    [WARNING] examples contains data to be imported, but the required component is not installed. Make sure  to define
              corresponding requirements.

This change adds EXT:impexp as dependency requirement.

Resolves: #253
Releases: main, 12.4