### PR TITLE
[BUGFIX] Avoid warning when set up extension (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## 12.0.5 - 2024-04-xx
+
+### Fixed
+- Warning when set up extension (#253)
+
 ## 12.0.4 - 2024-03-29
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "typo3/cms-extbase": "^12.4.9",
         "typo3/cms-fluid": "^12.4.9",
         "typo3/cms-fluid-styled-content": "^12.4.9",
+        "typo3/cms-impexp": "^12.4.9",
         "typo3/cms-linkvalidator": "^12.4.9",
         "typo3/cms-reactions": "^12.4.9"
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -29,6 +29,7 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'typo3' => '12.4.9-12.4.99',
             'fluid_styled_content' => '12.4.9-12.4.99',
+            'impexp' => '12.4.9-12.4.99',
             'linkvalidator' => '12.4.9-12.4.99',
         ],
         'conflicts' => [],


### PR DESCRIPTION
When running the command

    vendor/bin/typo3 setup:extension -e examples

the following warning was raised:

    [WARNING] examples contains data to be imported, but the required component is not installed. Make sure  to define
              corresponding requirements.

This change adds EXT:impexp as dependency requirement.

Resolves: #253
Releases: main, 12.4