### PR TITLE
[TASK] Add static code analyser `PHPStan` as code quality check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Rector
         run: Build/Scripts/runTests.sh -n -p ${{ env.php }} -s rector
 
+      - name: PHPStan
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s phpstan
+
   xliff-lint:
     name: "XLIFF linter"
     runs-on: ubuntu-latest

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -46,6 +46,8 @@ Options:
             - composerUpdate: "composer update", handy if host has no PHP
             - composerValidate: "composer validate"
             - lint: PHP linting
+            - phpstan: PHPStan static analysis
+            - phpstanBaseline: Generate PHPStan baseline
             - rector: Apply Rector rules
             - renderDocumentation
             - testRenderDocumentation
@@ -281,6 +283,16 @@ case ${TEST_SUITE} in
     lint)
         COMMAND="find . -name \\*.php ! -path "./.Build/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    phpstan)
+        COMMAND="php -dxdebug.mode=off .Build/bin/phpstan --configuration=Build/phpstan/phpstan.neon"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name phpstan-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    phpstanBaseline)
+        COMMAND="php -dxdebug.mode=off .Build/bin/phpstan --configuration=Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon -v"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name phpstan-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     rector)

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to an undefined property T3docs\\\\Examples\\\\Xclass\\\\NewRecordController\\:\\:\\$content\\.$#"
+			count: 1
+			path: ../../Classes/Xclass/NewRecordController.php

--- a/Build/phpstan/phpstan-typo3-constants.php
+++ b/Build/phpstan/phpstan-typo3-constants.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+defined('LF') ?: define('LF', chr(10));
+defined('CR') ?: define('CR', chr(13));
+defined('CRLF') ?: define('CRLF', CR . LF);

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -1,0 +1,19 @@
+includes:
+  - phpstan-baseline.neon
+
+parameters:
+  phpVersion: 80200
+  level: 1
+
+  bootstrapFiles:
+    - phpstan-typo3-constants.php
+
+  paths:
+    - ../../Classes
+    - ../../Configuration
+
+  inferPrivatePropertyTypeFromConstructor: true
+  treatPhpDocTypesAsCertain: false
+
+  # Use local cache dir instead of /tmp
+  tmpDir: ../../.Build/cache

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -161,7 +161,7 @@ class ModuleController extends ActionController implements LoggerAwareInterface
         /** @var $tree PageTreeView */
         $tree = GeneralUtility::makeInstance(PageTreeView::class);
         $tree->init('AND ' . $GLOBALS['BE_USER']->getPagePermsClause(1));
-
+        $html = '';
         if ($pageRecord) {
             $html = $this->iconFactory->getIconForRecord(
                 'pages',

--- a/Classes/DataProcessing/CustomCategoryProcessor.php
+++ b/Classes/DataProcessing/CustomCategoryProcessor.php
@@ -46,7 +46,7 @@ class CustomCategoryProcessor implements DataProcessorInterface
             return $processedData;
         }
         // categories by comma separated list
-        $categoryIdList = $cObj->stdWrapValue('categoryList', $processorConfiguration ?? []);
+        $categoryIdList = $cObj->stdWrapValue('categoryList', $processorConfiguration);
         $categories = [];
         if ($categoryIdList) {
             $categoryIdList = GeneralUtility::intExplode(',', (string)$categoryIdList, true);

--- a/Classes/Xclass/NewRecordController.php
+++ b/Classes/Xclass/NewRecordController.php
@@ -19,6 +19,10 @@ namespace T3docs\Examples\Xclass;
  * This class XCLASSes NewRecordController to modify the layout of the New Record Wizard
  *
  * @author Francois Suter <francois@typo3.org>
+ *
+ * @todo This example is broken and should be removed or fixed. Parent controller changes, most likely already for
+ *       TYPO3 v12. Property `$this->content` does no longer exists, and therefore the example does not demonstrate
+ *       anything working or useful - and will throw E_DEPRECATION with PHP 8.3 and corresponding error level.
  */
 class NewRecordController extends \TYPO3\CMS\Backend\Controller\NewRecordController
 {

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require-dev": {
         "ergebnis/composer-normalize": "~2.42.0",
         "friendsofphp/php-cs-fixer": "^3.52",
+        "phpstan/phpstan": "^1.10",
         "rector/rector": "1.0.3"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
The TYPO3 Core and the Best Practice Team recommends
to have a static code analyzer in the defense line,
and preferes PHPStan due to experience with that tool.

This change now adds the static code analyser `PHPStan`
with a first configurattion and a lower level as a start.
Levels can be raised step by step in follow-ups.

Note: XClass `Classes/Xclass/NewRecordController.php`
example does not work anymore, most likely since v12.
Added a comment to emphasize this, and that it should
be reworked or removed.

PHPStan can be run with

```terminal
Build/Scripts/runTests.sh -s phpstan
```

Generate baseline with

```terminal
Build/Scripts/runTests.sh -s phpstanBaseline
```


> Depends on #261