### PR TITLE
[TASK] Add exemplary site set settings definition

### DIFF
--- a/Configuration/Sets/Examples/settings.definitions.yaml
+++ b/Configuration/Sets/Examples/settings.definitions.yaml
@@ -1,0 +1,31 @@
+settings:
+  example.output.view.templateRootPath:
+    default: 'EXT:example/Resources/Private/Templates/'
+    label: 'Path to template root (FE)'
+    type: string
+    description: ''
+  example.output.view.partialRootPath:
+    default: 'EXT:example/Resources/Private/Partials/'
+    label: 'Path to template partials (FE)'
+    type: string
+    description: ''
+  example.output.view.layoutRootPath:
+    default: 'EXT:example/Resources/Private/Layouts/'
+    label: 'Path to template layouts (FE)'
+    type: string
+    description: ''
+  example.output.pages.excludedDoktypes:
+    default: '3, 4, 6, 7, 199, 254'
+    label: 'Doktypes to exclude'
+    type: string
+    description: ''
+  example.output.pages.excludePagesRecursive:
+    default: ''
+    label: 'List of page uids which should be excluded recursive'
+    type: string
+    description: ''
+  example.output.pages.additionalWhere:
+    default: "{#no_index} = 0 AND {#canonical_link} = ''"
+    label: 'Additional where clause'
+    type: string
+    description: ''

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -120,6 +120,20 @@ Extending TCA
 
 .. _introduction-credits:
 
+Site set settings
+=================
+
+Site set settings can be defined through a file like
+:file:`EXT:example/Configuration/Sets/Examples/settings.definitions.yaml`.
+
+Here is the auto-generated listing of all definitions. This is for example
+purposes only, and not yet implemented:
+
+..  typo3:site-set-settings:: EXT:self/Configuration/Sets/Examples/settings.definitions.yaml
+    :name: example-settings-definitions
+    :type:
+    :Label: Example site set settings definitions
+
 Credits
 =======
 


### PR DESCRIPTION
This showcases how the actual site set settings definition set of settings can be set in the documentation of auto-generated settable site set settings.