### PR TITLE
[TASK] Mark properties as private in AdminModuleController

### DIFF
--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -31,8 +31,8 @@ use TYPO3\CMS\Core\Localization\LanguageService;
 final readonly class AdminModuleController
 {
     public function __construct(
-        protected ModuleTemplateFactory $moduleTemplateFactory,
-        protected IconFactory $iconFactory,
+        private ModuleTemplateFactory $moduleTemplateFactory,
+        private IconFactory $iconFactory,
         private UriBuilder $uriBuilder,
         // ...
     ) {}


### PR DESCRIPTION
As the class is defined as final, it does not make sense to set the properties as protected as this class cannot be extended.

Releases: main, 12.4