### PR TITLE
[TASK] Mark properties as private in AdminModuleController (#283)

### DIFF
--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -30,8 +30,8 @@ use TYPO3\CMS\Core\Localization\LanguageService;
 final class AdminModuleController
 {
     public function __construct(
-        protected readonly ModuleTemplateFactory $moduleTemplateFactory,
-        protected readonly IconFactory $iconFactory,
+        private readonly ModuleTemplateFactory $moduleTemplateFactory,
+        private readonly IconFactory $iconFactory,
         // ...
     ) {}
 

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -52,7 +52,6 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  */
 class ModuleController extends ActionController
 {
-
     private int $pageUid;
     /** @var array<string, mixed> */
     private array $exampleConfig;


### PR DESCRIPTION
As the class is defined as final, it does not make sense to set the properties as protected as this class cannot be extended.

Releases: main, 12.4