### PR TITLE
fix glob pattern for resource

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -5,7 +5,7 @@ services:
     public: false
 
   T3docs\Examples\:
-    resource: '../Classes/*'
+    resource: '../Classes/**'
     exclude: '../Classes/Domain/Model/*'
 
   T3docs\Examples\LinkValidator\LinkType\ExampleLinkType:


### PR DESCRIPTION
All files in all folders must be found by the Glob Pattern.
The current pattern will only find the files in the Classes folder.