### PR TITLE
fix TYPO3 Exception 1303237468

### DIFF
--- a/Configuration/TCA/Overrides/sys_reaction.php
+++ b/Configuration/TCA/Overrides/sys_reaction.php
@@ -31,12 +31,15 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 defined('TYPO3') or die();
 
-ExtensionManagementUtility::addTcaSelectItem(
-    'sys_reaction',
-    'reaction_type',
-    [
-        'label' => ExampleReactionType::getDescription(),
-        'value' => ExampleReactionType::getType(),
-        'icon' => ExampleReactionType::getIconIdentifier(),
-    ],
-);
+if (ExtensionManagementUtility::isLoaded('reactions')) {
+
+    ExtensionManagementUtility::addTcaSelectItem(
+        'sys_reaction',
+        'reaction_type',
+        [
+            'label' => ExampleReactionType::getDescription(),
+            'value' => ExampleReactionType::getType(),
+            'icon' => ExampleReactionType::getIconIdentifier(),
+        ],
+    );
+}


### PR DESCRIPTION
The extension raises an exception when no system extension reactions has been activated.