### PR TITLE
Remove superfluous asterisk pattern

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -5,8 +5,8 @@ services:
     public: false
 
   T3docs\Examples\:
-    resource: '../Classes/*'
-    exclude: '../Classes/Domain/Model/*'
+    resource: '../Classes/'
+    exclude: '../Classes/Domain/Model/'
 
   T3docs\Examples\LinkValidator\LinkType\ExampleLinkType:
     tags:
@@ -31,7 +31,7 @@ services:
 
   T3docs\Examples\Controller\Haiku\ListController:
     public: true
-    
+
   T3docs\Examples\LinkHandler\GitHubLinkHandler:
     shared: false
     public: true


### PR DESCRIPTION
The TYPO3 docs example code should not contain superfluous unnecessary things like the asterisk in the Glob Pattern for the file Services.yaml. 
I have also made a patch for the testing of the TYPO3 Core without this asterisk. It seems that the former developer did not know that only the folders have to be configured and not the files. 
I have tested the TYPO3 Core 13 with this fix and did not find any new error.
