### PR TITLE
chore: use alias for FilesProcessor

### DIFF
--- a/Configuration/TypoScript/DataProcessors/Processors/DatabaseQueryProcessor.typoscript
+++ b/Configuration/TypoScript/DataProcessors/Processors/DatabaseQueryProcessor.typoscript
@@ -11,7 +11,7 @@ tt_content {
             as = myHaikus
             // recursively process the images in the records with the FilesProcessor
             dataProcessing {
-                10 = TYPO3\CMS\Frontend\DataProcessing\FilesProcessor
+                10 = files
                 10 {
                     references.fieldName = image
                 }


### PR DESCRIPTION
To be consistent to the usage of the database query data processor above in the same example, the alias is used for the files processor.