### PR TITLE
[BUGFIX] Update namespace of RecordLinkHandler

### DIFF
--- a/Configuration/TsConfig/Page/LinkBrowser/HaikuRecordLinkBrowser.tsconfig
+++ b/Configuration/TsConfig/Page/LinkBrowser/HaikuRecordLinkBrowser.tsconfig
@@ -1,6 +1,6 @@
 TCEMAIN.linkHandler {
     haiku {
-        handler = TYPO3\CMS\Recordlist\LinkHandler\RecordLinkHandler
+        handler = TYPO3\CMS\Backend\LinkHandler\RecordLinkHandler
         label = LLL:EXT:examples/Resources/Private/Language/locallang_browse_links.xlf:haiku
         configuration {
             table = tx_examples_haiku


### PR DESCRIPTION
The class `TYPO3\CMS\Recordlist\LinkHandler\RecordLinkHandler` was removed in https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-98443-ExtensionRecordlistMergedIntoBackend.html in TYPO3 12.0

TYPO3 12 still worked with the old handler setting, because there was an alias/fallback defined: https://github.com/TYPO3/typo3/blob/b4c9dea13902b0350263d70f189f622ee940eb71/typo3/sysext/backend/Configuration/Services.yaml#L126

The alias was removed in TYPO3 13 and the example in the documentation does not work anymore. 

This commit should be also backported to the `13.4` branch. Maybe even to `12.4`?