### PR TITLE
Remove "Distribution" category

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Core Documentation Code Examples',
     'description' => 'This extension packages a number of code examples from the Core Documentation.',
-    'category' => 'distribution',
+    'category' => 'misc',
     'author' => 'Documentation Team',
     'author_email' => 'documentation@typo3.org',
     'state' => 'stable',


### PR DESCRIPTION
This category causes the extension to appear in the Extension Manager for Classic installations when extensions are being loaded.

See https://forge.typo3.org/issues/106701